### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ruby Stellar
 
-[![Build Status](https://travis-ci.org/stellar/ruby-stellar-sdk.svg)](https://travis-ci.org/stellar/ruby-stellar-lib)
+[![Build Status](https://travis-ci.org/stellar/ruby-stellar-sdk.svg)](https://travis-ci.org/stellar/ruby-stellar-sdk)
 [![Code Climate](https://codeclimate.com/github/stellar/ruby-stellar-sdk/badges/gpa.svg)](https://codeclimate.com/github/stellar/ruby-stellar-sdk)
 
 *STATUS:  this library is very early and incomplete.  The examples provided do not work, yet*

--- a/lib/stellar/version.rb
+++ b/lib/stellar/version.rb
@@ -1,3 +1,3 @@
 module Stellar
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
1) Looks like the travis-ci link was not updated. 
2) Code Climate repository has also not been renamed from ruby-stellar-lib -> ruby-stellar-sdk.