### PR TITLE
Hyperclient expects an account_id parameter

### DIFF
--- a/lib/stellar/client.rb
+++ b/lib/stellar/client.rb
@@ -49,8 +49,8 @@ module Stellar
     # Contract Stellar::Account => Stellar::AccountInfo
     Contract Stellar::Account => Any
     def account_info(account)
-      address  = account.address
-      @horizon.account(address:address)
+      account_id  = account.address
+      @horizon.account(account_id:account_id)
     end
 
     Contract ({


### PR DESCRIPTION
HyperClient was failing to follow the correct links due to it expecting an account_id parameter and not an address parameter.