### PR TITLE
Adding support for Federation lookup

### DIFF
--- a/lib/stellar/account.rb
+++ b/lib/stellar/account.rb
@@ -1,3 +1,6 @@
+require 'toml-rb'
+require 'uri'
+
 module Stellar
   class Account
     include Contracts
@@ -20,7 +23,36 @@ module Stellar
     end
 
     def self.lookup(federated_name)
-      raise NotImplementedError
+      _, domain = federated_name.split('*')
+      if domain.nil?
+        raise InvalidFederationAddress.new
+      end
+
+      domain_req = Faraday.new("https://#{domain}/.well-known/stellar.toml").get
+
+      unless domain_req.status == 200
+        raise InvalidStellarDomain.new('Domain does not contain stellar.toml file')
+      end
+      
+      fed_server_url = TomlRB.parse(domain_req.body)["FEDERATION_SERVER"]
+      if fed_server_url.nil?
+        raise InvalidStellarTOML.new('Invalid Stellar TOML file')
+      end
+
+      unless fed_server_url =~ URI::regexp
+        raise InvalidFederationURL.new('Invalid Federation Server URL')
+      end
+
+      lookup_req = Faraday.new(fed_server_url).get do |req|
+        req.params[:q] = federated_name
+        req.params[:type] = 'name'
+      end
+
+      unless lookup_req.status == 200
+        raise AccountNotFound.new('Account not found')
+      end
+
+      JSON.parse(lookup_req.body)["account_id"]
     end
 
     def self.master
@@ -34,5 +66,20 @@ module Stellar
     def initialize(keypair)
       @keypair = keypair
     end
+  end
+
+  class AccountNotFound < StandardError
+  end
+
+  class InvalidStellarTOML < StandardError
+  end
+
+  class InvalidFederationAddress < StandardError
+  end
+
+  class InvalidStellarDomain < StandardError
+  end
+
+  class InvalidFederationURL < StandardError
   end
 end

--- a/ruby-stellar-sdk.gemspec
+++ b/ruby-stellar-sdk.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "excon", "~> 0.44.4"
   spec.add_dependency "contracts", "~> 0.7"
   spec.add_dependency "activesupport", ">= 4.2.7"
+  spec.add_dependency "toml-rb", "~> 1.1.1"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/fixtures/vcr_cassettes/Stellar_Account/_lookup/should_handle_404_request_when_performing_federation_lookup.yml
+++ b/spec/fixtures/vcr_cassettes/Stellar_Account/_lookup/should_handle_404_request_when_performing_federation_lookup.yml
@@ -1,0 +1,133 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://stellarfed.org/.well-known/stellar.toml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 20 Feb 2018 18:58:58 GMT
+      Content-Type:
+      - text/plain; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=de30e4abf7a551661d3deb92e6e3716011519153138; expires=Wed, 20-Feb-19
+        18:58:58 GMT; path=/; domain=.stellarfed.org; HttpOnly; Secure
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"e00cc6ea5aab41de546253c69965d937"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 6a387582-adbe-4bfd-836b-eabf658fce22
+      X-Runtime:
+      - '0.002500'
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Via:
+      - 1.1 vegur
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 3f03b34b0e799266-EWR
+    body:
+      encoding: ASCII-8BIT
+      string: FEDERATION_SERVER = "https://stellarfed.org/federation"
+    http_version: 
+  recorded_at: Tue, 20 Feb 2018 18:58:58 GMT
+- request:
+    method: get
+    uri: https://stellarfed.org/federation?q=jane@email.com*stellarfed.org&type=name
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 20 Feb 2018 18:58:58 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d164f4eba862038aaf9e96d9ac755d9471519153138; expires=Wed, 20-Feb-19
+        18:58:58 GMT; path=/; domain=.stellarfed.org; HttpOnly; Secure
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 2b9424e9-6cb3-4cdc-915e-469f8e2123e3
+      X-Runtime:
+      - '0.004981'
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Via:
+      - 1.1 vegur
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 3f03b34bbd5c91d0-EWR
+    body:
+      encoding: ASCII-8BIT
+      string: '{"detail":"no record found"}'
+    http_version: 
+  recorded_at: Tue, 20 Feb 2018 18:58:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Stellar_Account/_lookup/should_handle_domains_that_are_not_federation_servers.yml
+++ b/spec/fixtures/vcr_cassettes/Stellar_Account/_lookup/should_handle_domains_that_are_not_federation_servers.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://stellar.org/.well-known/stellar.toml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 20 Feb 2018 19:11:53 GMT
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - max-age=3600
+      Expires:
+      - Tue, 20 Feb 2018 20:11:53 GMT
+      Location:
+      - https://www.stellar.org/.well-known/stellar.toml
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 3f03c6383855215c-EWR
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 20 Feb 2018 19:11:53 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Stellar_Account/_lookup/should_peforms_federation_lookup.yml
+++ b/spec/fixtures/vcr_cassettes/Stellar_Account/_lookup/should_peforms_federation_lookup.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://stellarfed.org/.well-known/stellar.toml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.8
+      Date:
+      - Tue, 20 Feb 2018 18:58:57 GMT
+      Content-Type:
+      - text/plain; charset=utf-8
+      Last-Modified:
+      - Thu, 08 Feb 2018 03:32:08 GMT
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Etag:
+      - W/"5a7bc4b8-63"
+      Access-Control-Allow-Origin:
+      - "*"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        # Federation service provided by stellarfed.org
+        FEDERATION_SERVER="https://stellarfed.org/federation/"
+    http_version: 
+  recorded_at: Tue, 20 Feb 2018 18:58:57 GMT
+- request:
+    method: get
+    uri: https://stellarfed.org/federation/?q=john@email.com*stellarfed.org&type=name
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.8
+      Date:
+      - Tue, 20 Feb 2018 18:58:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '114'
+      Connection:
+      - keep-alive
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=7776000; includeSubdomains
+    body:
+      encoding: UTF-8
+      string: '{"stellar_address": "john@email.com*stellarfed.org", "account_id": "GDSRO6H2YM6MC6ZO7KORPJXSTUMBMT3E7MZ66CFVNMUAULFG6G2OP32I"}'
+    http_version: 
+  recorded_at: Tue, 20 Feb 2018 18:58:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/lib/stellar/account_spec.rb
+++ b/spec/lib/stellar/account_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+module Stellar
+  RSpec.describe Account do
+
+    describe "#lookup" do
+      it "should peforms federation lookup", vcr: {record: :once, match_requests_on: [:method]} do
+        account_id = described_class.lookup('john@email.com*stellarfed.org')
+        expect(account_id).to eq 'GDSRO6H2YM6MC6ZO7KORPJXSTUMBMT3E7MZ66CFVNMUAULFG6G2OP32I'
+      end
+
+      it "should handle 404 request when performing federation lookup", vcr: {record: :once, match_requests_on: [:method]} do
+        expect { described_class.lookup('jane@email.com*stellarfed.org') }.to raise_error(AccountNotFound)
+      end
+
+      it "should handle domains that are not federation servers", vcr: {record: :once, match_requests_on: [:method]} do
+        expect { described_class.lookup('john*stellar.org') }.to raise_error(InvalidStellarDomain)
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Perform lookup using federation address. Ex: `john*domain.com` or `john@email.com*domain.com`