### PR TITLE
Set create account fee to be reasonable

### DIFF
--- a/lib/stellar/client.rb
+++ b/lib/stellar/client.rb
@@ -81,7 +81,7 @@ module Stellar
     def create_account(options={})
       funder   = options[:funder]
       sequence = options[:sequence] || (account_info(funder).sequence.to_i + 1)
-      fee = options[:fee] || 100 * Stellar::ONE
+      fee = options[:fee] || 100
 
       payment = Stellar::Transaction.create_account({
         account:          funder.keypair,

--- a/lib/stellar/client.rb
+++ b/lib/stellar/client.rb
@@ -81,6 +81,8 @@ module Stellar
     def create_account(options={})
       funder   = options[:funder]
       sequence = options[:sequence] || (account_info(funder).sequence.to_i + 1)
+      # In the future, the fee should be grabbed from the network's last transactions,
+      # instead of using a hard-coded default value.
       fee = options[:fee] || 100
 
       payment = Stellar::Transaction.create_account({


### PR DESCRIPTION
Create_account was failing for me, and this was because the default fee was hard-coded to be HUGE.  When I use the Stellar Laboratory, it uses a fee of 100 which looks correct given the current network.