### PR TITLE
Remove `Bundler.setup` code

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
 require "bundler/gem_tasks"
-Bundler.setup
 
 Dir["tasks/**/*.rake"].each{|f| load f}

--- a/ruby-stellar-sdk.gemspec
+++ b/ruby-stellar-sdk.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 4.2.7"
   spec.add_dependency "toml-rb", "~> 1.1", ">= 1.1.1"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.1"
   spec.add_development_dependency "guard-rspec"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,3 @@
-require 'bundler/setup'
-Bundler.setup
-
 require 'simplecov'
 SimpleCov.start
 


### PR DESCRIPTION
It does not (perhaps no longer?) shows up when doing `bundle gem newgem`