### PR TITLE
Add support for source acc. in Client#send_payment

### DIFF
--- a/lib/stellar/client.rb
+++ b/lib/stellar/client.rb
@@ -118,8 +118,7 @@ module Stellar
         amount:      options[:amount].to_payment,
       }
 
-      if options[:source_account]
-        source_account = options[:source_account]
+      if source_account = options[:source_account]
         payment_details[:source_account] = source_account.keypair
       end
 

--- a/lib/stellar/client.rb
+++ b/lib/stellar/client.rb
@@ -125,11 +125,10 @@ module Stellar
 
       payment = Stellar::Transaction.payment(payment_details)
 
-      if source_account
-        envelope_base64 = payment.to_envelope(from.keypair, source_account.keypair).to_xdr(:base64)
-      else
-        envelope_base64 = payment.to_envelope(from.keypair).to_xdr(:base64)
-      end
+      to_envelope_args = [from.keypair]
+      to_envelope_args << source_account.keypair if !source_account.nil?
+
+      envelope_base64 = payment.to_envelope(*to_envelope_args).to_xdr(:base64)
       @horizon.transactions._post(tx: envelope_base64)
     end
 

--- a/spec/fixtures/vcr_cassettes/Stellar_Client/_send_payment/native_asset/sends_a_native_payment_to_the_account.yml
+++ b/spec/fixtures/vcr_cassettes/Stellar_Client/_send_payment/native_asset/sends_a_native_payment_to_the_account.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.9.2
+      - Faraday v0.15.2
       Accept:
       - application/hal+json,application/problem+json,application/json
   response:
@@ -16,22 +16,35 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Date:
+      - Thu, 13 Sep 2018 09:18:17 GMT
       Content-Type:
       - application/hal+json; charset=utf-8
-      Date:
-      - Sun, 26 Mar 2017 07:28:49 GMT
-      X-Ratelimit-Limit:
-      - '72000'
-      X-Ratelimit-Remaining:
-      - '71946'
-      X-Ratelimit-Reset:
-      - '2156'
-      Content-Length:
-      - '1366'
       Connection:
       - keep-alive
+      Set-Cookie:
+      - __cfduid=d1833a496d2e62cab79ef883bcbc2f7631536830297; expires=Fri, 13-Sep-19
+        09:18:17 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17188'
+      X-Ratelimit-Reset:
+      - '2303'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4599868e1cb1aa2c-SIN
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |-
         {
           "_links": {
@@ -43,15 +56,19 @@ http_interactions:
               "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
               "templated": true
             },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
             "friendbot": {
-              "href": "https://horizon-testnet.stellar.org/friendbot{?addr}",
+              "href": "https://friendbot.stellar.org/{?addr}",
               "templated": true
             },
             "metrics": {
               "href": "https://horizon-testnet.stellar.org/metrics"
             },
             "order_book": {
-              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_issuer,buying_asset_type,buying_asset_code,buying_issuer}",
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
               "templated": true
             },
             "self": {
@@ -66,17 +83,16 @@ http_interactions:
               "templated": true
             }
           },
-          "horizon_version": "v0.10.0-3-g50eda21",
-          "core_version": "v0.6.1-2-g12a1603",
-          "history_latest_ledger": 124860,
+          "horizon_version": "0.14.0-81f12a7e313bc469b229cd89c7843a7fc1db9403",
+          "core_version": "stellar-core 10.0.0 (1fc018b4f52e8c7e716b023ccf30600af5b4f66d)",
+          "history_latest_ledger": 11030034,
           "history_elder_ledger": 1,
-          "core_latest_ledger": 124860,
-          "core_elder_ledger": 1,
+          "core_latest_ledger": 11030034,
           "network_passphrase": "Test SDF Network ; September 2015",
-          "protocol_version": 4
+          "protocol_version": 10
         }
     http_version: 
-  recorded_at: Sun, 26 Mar 2017 07:28:48 GMT
+  recorded_at: Thu, 13 Sep 2018 09:18:17 GMT
 - request:
     method: get
     uri: https://horizon-testnet.stellar.org/accounts/[source_address]
@@ -85,7 +101,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.9.2
+      - Faraday v0.15.2
       Accept:
       - application/hal+json,application/problem+json,application/json
   response:
@@ -93,20 +109,35 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Date:
+      - Thu, 13 Sep 2018 09:18:19 GMT
       Content-Type:
       - application/hal+json; charset=utf-8
-      Date:
-      - Sun, 26 Mar 2017 07:28:50 GMT
-      X-Ratelimit-Limit:
-      - '72000'
-      X-Ratelimit-Remaining:
-      - '71945'
-      X-Ratelimit-Reset:
-      - '2155'
       Connection:
       - keep-alive
+      Set-Cookie:
+      - __cfduid=dbb86d1a7f686af4c42ba7e1fd38020e21536830298; expires=Fri, 13-Sep-19
+        09:18:18 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17187'
+      X-Ratelimit-Reset:
+      - '2302'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 459986933bcea960-SIN
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |-
         {
           "_links": {
@@ -145,7 +176,7 @@ http_interactions:
           "id": "[source_address]",
           "paging_token": "",
           "account_id": "[source_address]",
-          "sequence": "346973227974694",
+          "sequence": "39136008289124450",
           "subentry_count": 0,
           "thresholds": {
             "low_threshold": 0,
@@ -158,7 +189,9 @@ http_interactions:
           },
           "balances": [
             {
-              "balance": "4749.9998600",
+              "balance": "9099.9990200",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
               "asset_type": "native"
             }
           ],
@@ -173,16 +206,16 @@ http_interactions:
           "data": {}
         }
     http_version: 
-  recorded_at: Sun, 26 Mar 2017 07:28:49 GMT
+  recorded_at: Thu, 13 Sep 2018 09:18:19 GMT
 - request:
     method: post
     uri: https://horizon-testnet.stellar.org/transactions
     body:
       encoding: UTF-8
-      string: tx=AAAAAKEiSt7wL8zHIfwsJF5PvoI%2FqW7Epb2ihhiW7lxPpHJCO5rKAAABO5IAAAAnAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA3EVejc%2BkLyLyCCoS3V6dhSxNnPdQkAV2zvUkRTyAdLsAAAAAO5rKAAAAAAAAAAABT6RyQgAAAEBMVplDCKfB%2FOZaf%2FLGaOI3pLL00YzE%2FI%2Fyvsnmy5Y3oPNCHmIwkUDgTC5Eob7cXqGVpy92VdwjoMXeUz5Imz4E
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAABjAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAepECwCoxp0fylsWNA9YK0zPuEcGVuNB66PouDS8nGLsAAAAAO5rKAAAAAAAAAAABKATZaAAAAEByWq95JD072oQsw7sMhB03MqZQ481XJHdlWHdLW1Jz4GYfOGbCHc9fH3c2DT1qGiH%2FZFXDyTcrnz4AyBKp0BAN
     headers:
       User-Agent:
-      - Faraday v0.9.2
+      - Faraday v0.15.2
       Accept:
       - application/hal+json,application/problem+json,application/json
       Content-Type:
@@ -192,37 +225,50 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Date:
+      - Thu, 13 Sep 2018 09:18:26 GMT
       Content-Type:
       - application/hal+json; charset=utf-8
-      Date:
-      - Sun, 26 Mar 2017 07:28:56 GMT
-      X-Ratelimit-Limit:
-      - '72000'
-      X-Ratelimit-Remaining:
-      - '71944'
-      X-Ratelimit-Reset:
-      - '2154'
-      Content-Length:
-      - '915'
       Connection:
       - keep-alive
+      Set-Cookie:
+      - __cfduid=dce39377d1b5a221c870d111b43c71a571536830300; expires=Fri, 13-Sep-19
+        09:18:20 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17185'
+      X-Ratelimit-Reset:
+      - '2299'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4599869f7e5fa984-SIN
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |-
         {
           "_links": {
             "transaction": {
-              "href": "https://horizon-testnet.stellar.org/transactions/4e61a390afc10a26f6fe64470cff4f8b7e58a6dd237743d2e674343ae4edcf53"
+              "href": "https://horizon-testnet.stellar.org/transactions/c625c3e37a0eeee06c5f41443ec9bc2e00fd3f4c1aed0f5a4d6f3a63fe6dc525"
             }
           },
-          "hash": "4e61a390afc10a26f6fe64470cff4f8b7e58a6dd237743d2e674343ae4edcf53",
-          "ledger": 124862,
-          "envelope_xdr": "AAAAAKEiSt7wL8zHIfwsJF5PvoI/qW7Epb2ihhiW7lxPpHJCO5rKAAABO5IAAAAnAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA3EVejc+kLyLyCCoS3V6dhSxNnPdQkAV2zvUkRTyAdLsAAAAAO5rKAAAAAAAAAAABT6RyQgAAAEBMVplDCKfB/OZaf/LGaOI3pLL00YzE/I/yvsnmy5Y3oPNCHmIwkUDgTC5Eob7cXqGVpy92VdwjoMXeUz5Imz4E",
-          "result_xdr": "AAAAADuaygAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
-          "result_meta_xdr": "AAAAAAAAAAEAAAACAAAAAAAB574AAAAAAAAAANxFXo3PpC8i8ggqEt1enYUsTZz3UJAFds71JEU8gHS7AAAAADuaygAAAee+AAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQAB574AAAAAAAAAAKEiSt7wL8zHIfwsJF5PvoI/qW7Epb2ihhiW7lxPpHJCAAAACpgC4YgAATuSAAAAJwAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAA"
+          "hash": "c625c3e37a0eeee06c5f41443ec9bc2e00fd3f4c1aed0f5a4d6f3a63fe6dc525",
+          "ledger": 11030036,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAABjAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAepECwCoxp0fylsWNA9YK0zPuEcGVuNB66PouDS8nGLsAAAAAO5rKAAAAAAAAAAABKATZaAAAAEByWq95JD072oQsw7sMhB03MqZQ481XJHdlWHdLW1Jz4GYfOGbCHc9fH3c2DT1qGiH/ZFXDyTcrnz4AyBKp0BAN",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAKhOFAAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAVMAWnVACLCf4AAABiAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAKhOFAAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAVMAWnVACLCf4AAABjAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAqE4UAAAAAAAAAAB6kQLAKjGnR/KWxY0D1grTM+4RwZW40Hro+i4NLycYuwAAAAA7msoAAKhOFAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAqE4UAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABUwBadUAIsJ/gAAAGMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAqE4UAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABT0at1UAIsJ/gAAAGMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
         }
     http_version: 
-  recorded_at: Sun, 26 Mar 2017 07:28:55 GMT
+  recorded_at: Thu, 13 Sep 2018 09:18:26 GMT
 - request:
     method: get
     uri: https://horizon-testnet.stellar.org/accounts/[source_address]
@@ -231,7 +277,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.9.2
+      - Faraday v0.15.2
       Accept:
       - application/hal+json,application/problem+json,application/json
   response:
@@ -239,20 +285,35 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Date:
+      - Thu, 13 Sep 2018 09:18:28 GMT
       Content-Type:
       - application/hal+json; charset=utf-8
-      Date:
-      - Sun, 26 Mar 2017 07:28:58 GMT
-      X-Ratelimit-Limit:
-      - '72000'
-      X-Ratelimit-Remaining:
-      - '71943'
-      X-Ratelimit-Reset:
-      - '2147'
       Connection:
       - keep-alive
+      Set-Cookie:
+      - __cfduid=d01cae6500bf57f7e3a855724304ec2601536830307; expires=Fri, 13-Sep-19
+        09:18:27 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17186'
+      X-Ratelimit-Reset:
+      - '2292'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 459986cf480eaa32-SIN
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |-
         {
           "_links": {
@@ -291,7 +352,7 @@ http_interactions:
           "id": "[source_address]",
           "paging_token": "",
           "account_id": "[source_address]",
-          "sequence": "346973227974695",
+          "sequence": "39136008289124451",
           "subentry_count": 0,
           "thresholds": {
             "low_threshold": 0,
@@ -304,7 +365,9 @@ http_interactions:
           },
           "balances": [
             {
-              "balance": "4549.9998600",
+              "balance": "8999.9990100",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
               "asset_type": "native"
             }
           ],
@@ -319,16 +382,16 @@ http_interactions:
           "data": {}
         }
     http_version: 
-  recorded_at: Sun, 26 Mar 2017 07:28:57 GMT
+  recorded_at: Thu, 13 Sep 2018 09:18:28 GMT
 - request:
     method: post
     uri: https://horizon-testnet.stellar.org/transactions
     body:
       encoding: UTF-8
-      string: tx=AAAAAKEiSt7wL8zHIfwsJF5PvoI%2FqW7Epb2ihhiW7lxPpHJCAAAAZAABO5IAAAAoAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAA3EVejc%2BkLyLyCCoS3V6dhSxNnPdQkAV2zvUkRTyAdLsAAAAAAAAAAFloLwAAAAAAAAAAAU%2BkckIAAABAtkN4J57xCr%2BBdg5TvYnp%2FC8LZBzFT891v%2BIKb8Cmq0gEHw79gVDWTY1%2FCZU4IhZ00v5nluViECmJ%2FDPnX0JTAQ%3D%3D
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAABkAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAepECwCoxp0fylsWNA9YK0zPuEcGVuNB66PouDS8nGLsAAAAAAAAAAFloLwAAAAAAAAAAASgE2WgAAABA6EkilxPX0yc0%2B4NEzZxMbSBt7FKgM1CkGexD3D3JKOAeGx%2FGIbpSntQf6y8YRwA8uCHu5bo2D8I2Ae%2BolheiBg%3D%3D
     headers:
       User-Agent:
-      - Faraday v0.9.2
+      - Faraday v0.15.2
       Accept:
       - application/hal+json,application/problem+json,application/json
       Content-Type:
@@ -338,46 +401,59 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Date:
+      - Thu, 13 Sep 2018 09:18:39 GMT
       Content-Type:
       - application/hal+json; charset=utf-8
-      Date:
-      - Sun, 26 Mar 2017 07:29:01 GMT
-      X-Ratelimit-Limit:
-      - '72000'
-      X-Ratelimit-Remaining:
-      - '71942'
-      X-Ratelimit-Reset:
-      - '2146'
-      Content-Length:
-      - '1051'
       Connection:
       - keep-alive
+      Set-Cookie:
+      - __cfduid=d20d22fda7b7878faadbbe6712b1436dc1536830309; expires=Fri, 13-Sep-19
+        09:18:29 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17184'
+      X-Ratelimit-Reset:
+      - '2289'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 459986dd5dbaa302-HKG
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |-
         {
           "_links": {
             "transaction": {
-              "href": "https://horizon-testnet.stellar.org/transactions/116d0ba7bd66f7d50141db0a78f2c8fe13a4bc87a47eeb1ec331fb5a0a347521"
+              "href": "https://horizon-testnet.stellar.org/transactions/b6f882305ca3244e126921ea929a9c41fd39e81e31e6ef58517a094d15bb22f7"
             }
           },
-          "hash": "116d0ba7bd66f7d50141db0a78f2c8fe13a4bc87a47eeb1ec331fb5a0a347521",
-          "ledger": 124863,
-          "envelope_xdr": "AAAAAKEiSt7wL8zHIfwsJF5PvoI/qW7Epb2ihhiW7lxPpHJCAAAAZAABO5IAAAAoAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAA3EVejc+kLyLyCCoS3V6dhSxNnPdQkAV2zvUkRTyAdLsAAAAAAAAAAFloLwAAAAAAAAAAAU+kckIAAABAtkN4J57xCr+Bdg5TvYnp/C8LZBzFT891v+IKb8Cmq0gEHw79gVDWTY1/CZU4IhZ00v5nluViECmJ/DPnX0JTAQ==",
+          "hash": "b6f882305ca3244e126921ea929a9c41fd39e81e31e6ef58517a094d15bb22f7",
+          "ledger": 11030038,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAABkAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAepECwCoxp0fylsWNA9YK0zPuEcGVuNB66PouDS8nGLsAAAAAAAAAAFloLwAAAAAAAAAAASgE2WgAAABA6EkilxPX0yc0+4NEzZxMbSBt7FKgM1CkGexD3D3JKOAeGx/GIbpSntQf6y8YRwA8uCHu5bo2D8I2Ae+olheiBg==",
           "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
-          "result_meta_xdr": "AAAAAAAAAAEAAAADAAAAAQAB578AAAAAAAAAAKEiSt7wL8zHIfwsJF5PvoI/qW7Epb2ihhiW7lxPpHJCAAAACj6asiQAATuSAAAAKAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAwAB574AAAAAAAAAANxFXo3PpC8i8ggqEt1enYUsTZz3UJAFds71JEU8gHS7AAAAADuaygAAAee+AAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQAB578AAAAAAAAAANxFXo3PpC8i8ggqEt1enYUsTZz3UJAFds71JEU8gHS7AAAAAJUC+QAAAee+AAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAA"
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAKhOFgAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAU9Grc8ACLCf4AAABjAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAKhOFgAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAU9Grc8ACLCf4AAABkAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMAqE4UAAAAAAAAAAB6kQLAKjGnR/KWxY0D1grTM+4RwZW40Hro+i4NLycYuwAAAAA7msoAAKhOFAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAqE4WAAAAAAAAAAB6kQLAKjGnR/KWxY0D1grTM+4RwZW40Hro+i4NLycYuwAAAACVAvkAAKhOFAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAqE4WAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABT0atzwAIsJ/gAAAGQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAqE4WAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABSbAq3wAIsJ/gAAAGQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
         }
     http_version: 
-  recorded_at: Sun, 26 Mar 2017 07:29:00 GMT
+  recorded_at: Thu, 13 Sep 2018 09:18:39 GMT
 - request:
     method: get
-    uri: https://horizon-testnet.stellar.org/accounts/GDOEKXUNZ6SC6IXSBAVBFXK6TWCSYTM465IJABLWZ32SIRJ4QB2LW247
+    uri: https://horizon-testnet.stellar.org/accounts/GB5JCAWAFIY2OR7SS3CY2A6WBLJTH3QRYGK3RUD25D5C4DJPE4MLW2IG
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.9.2
+      - Faraday v0.15.2
       Accept:
       - application/hal+json,application/problem+json,application/json
   response:
@@ -385,59 +461,74 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Date:
+      - Thu, 13 Sep 2018 09:18:41 GMT
       Content-Type:
       - application/hal+json; charset=utf-8
-      Date:
-      - Sun, 26 Mar 2017 07:29:02 GMT
-      X-Ratelimit-Limit:
-      - '72000'
-      X-Ratelimit-Remaining:
-      - '71941'
-      X-Ratelimit-Reset:
-      - '2142'
       Connection:
       - keep-alive
+      Set-Cookie:
+      - __cfduid=d3822694aeeae8b689752fbb4646923db1536830320; expires=Fri, 13-Sep-19
+        09:18:40 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17185'
+      X-Ratelimit-Reset:
+      - '2280'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4599871e1ace84c6-HKG
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |-
         {
           "_links": {
             "self": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GDOEKXUNZ6SC6IXSBAVBFXK6TWCSYTM465IJABLWZ32SIRJ4QB2LW247"
+              "href": "https://horizon-testnet.stellar.org/accounts/GB5JCAWAFIY2OR7SS3CY2A6WBLJTH3QRYGK3RUD25D5C4DJPE4MLW2IG"
             },
             "transactions": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GDOEKXUNZ6SC6IXSBAVBFXK6TWCSYTM465IJABLWZ32SIRJ4QB2LW247/transactions{?cursor,limit,order}",
+              "href": "https://horizon-testnet.stellar.org/accounts/GB5JCAWAFIY2OR7SS3CY2A6WBLJTH3QRYGK3RUD25D5C4DJPE4MLW2IG/transactions{?cursor,limit,order}",
               "templated": true
             },
             "operations": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GDOEKXUNZ6SC6IXSBAVBFXK6TWCSYTM465IJABLWZ32SIRJ4QB2LW247/operations{?cursor,limit,order}",
+              "href": "https://horizon-testnet.stellar.org/accounts/GB5JCAWAFIY2OR7SS3CY2A6WBLJTH3QRYGK3RUD25D5C4DJPE4MLW2IG/operations{?cursor,limit,order}",
               "templated": true
             },
             "payments": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GDOEKXUNZ6SC6IXSBAVBFXK6TWCSYTM465IJABLWZ32SIRJ4QB2LW247/payments{?cursor,limit,order}",
+              "href": "https://horizon-testnet.stellar.org/accounts/GB5JCAWAFIY2OR7SS3CY2A6WBLJTH3QRYGK3RUD25D5C4DJPE4MLW2IG/payments{?cursor,limit,order}",
               "templated": true
             },
             "effects": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GDOEKXUNZ6SC6IXSBAVBFXK6TWCSYTM465IJABLWZ32SIRJ4QB2LW247/effects{?cursor,limit,order}",
+              "href": "https://horizon-testnet.stellar.org/accounts/GB5JCAWAFIY2OR7SS3CY2A6WBLJTH3QRYGK3RUD25D5C4DJPE4MLW2IG/effects{?cursor,limit,order}",
               "templated": true
             },
             "offers": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GDOEKXUNZ6SC6IXSBAVBFXK6TWCSYTM465IJABLWZ32SIRJ4QB2LW247/offers{?cursor,limit,order}",
+              "href": "https://horizon-testnet.stellar.org/accounts/GB5JCAWAFIY2OR7SS3CY2A6WBLJTH3QRYGK3RUD25D5C4DJPE4MLW2IG/offers{?cursor,limit,order}",
               "templated": true
             },
             "trades": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GDOEKXUNZ6SC6IXSBAVBFXK6TWCSYTM465IJABLWZ32SIRJ4QB2LW247/trades{?cursor,limit,order}",
+              "href": "https://horizon-testnet.stellar.org/accounts/GB5JCAWAFIY2OR7SS3CY2A6WBLJTH3QRYGK3RUD25D5C4DJPE4MLW2IG/trades{?cursor,limit,order}",
               "templated": true
             },
             "data": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GDOEKXUNZ6SC6IXSBAVBFXK6TWCSYTM465IJABLWZ32SIRJ4QB2LW247/data/{key}",
+              "href": "https://horizon-testnet.stellar.org/accounts/GB5JCAWAFIY2OR7SS3CY2A6WBLJTH3QRYGK3RUD25D5C4DJPE4MLW2IG/data/{key}",
               "templated": true
             }
           },
-          "id": "GDOEKXUNZ6SC6IXSBAVBFXK6TWCSYTM465IJABLWZ32SIRJ4QB2LW247",
+          "id": "GB5JCAWAFIY2OR7SS3CY2A6WBLJTH3QRYGK3RUD25D5C4DJPE4MLW2IG",
           "paging_token": "",
-          "account_id": "GDOEKXUNZ6SC6IXSBAVBFXK6TWCSYTM465IJABLWZ32SIRJ4QB2LW247",
-          "sequence": "536278206513152",
+          "account_id": "GB5JCAWAFIY2OR7SS3CY2A6WBLJTH3QRYGK3RUD25D5C4DJPE4MLW2IG",
+          "sequence": "47373643893702656",
           "subentry_count": 0,
           "thresholds": {
             "low_threshold": 0,
@@ -451,19 +542,21 @@ http_interactions:
           "balances": [
             {
               "balance": "250.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
               "asset_type": "native"
             }
           ],
           "signers": [
             {
-              "public_key": "GDOEKXUNZ6SC6IXSBAVBFXK6TWCSYTM465IJABLWZ32SIRJ4QB2LW247",
+              "public_key": "GB5JCAWAFIY2OR7SS3CY2A6WBLJTH3QRYGK3RUD25D5C4DJPE4MLW2IG",
               "weight": 1,
-              "key": "GDOEKXUNZ6SC6IXSBAVBFXK6TWCSYTM465IJABLWZ32SIRJ4QB2LW247",
+              "key": "GB5JCAWAFIY2OR7SS3CY2A6WBLJTH3QRYGK3RUD25D5C4DJPE4MLW2IG",
               "type": "ed25519_public_key"
             }
           ],
           "data": {}
         }
     http_version: 
-  recorded_at: Sun, 26 Mar 2017 07:29:01 GMT
+  recorded_at: Thu, 13 Sep 2018 09:18:41 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Stellar_Client/_send_payment/native_asset/sends_a_native_payment_to_the_account_through_a_channel_account.yml
+++ b/spec/fixtures/vcr_cassettes/Stellar_Client/_send_payment/native_asset/sends_a_native_payment_to_the_account_through_a_channel_account.yml
@@ -1,0 +1,738 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 10 Sep 2018 13:43:47 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dee2e445b2ae53bcadc9d543367c063ed1536587027; expires=Tue, 10-Sep-19
+        13:43:47 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17190'
+      X-Ratelimit-Reset:
+      - '3464'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4582535959d19901-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "metrics": {
+              "href": "https://horizon-testnet.stellar.org/metrics"
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "0.14.0-81f12a7e313bc469b229cd89c7843a7fc1db9403",
+          "core_version": "stellar-core 10.0.0 (1fc018b4f52e8c7e716b023ccf30600af5b4f66d)",
+          "history_latest_ledger": 10982802,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 10982802,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "protocol_version": 10
+        }
+    http_version: 
+  recorded_at: Mon, 10 Sep 2018 13:43:47 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 10 Sep 2018 13:43:48 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d32eeb89fb81a67f6d8c790c4c9c5cfd31536587028; expires=Tue, 10-Sep-19
+        13:43:48 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17192'
+      X-Ratelimit-Reset:
+      - '3460'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 458253608ea69901-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "paging_token": "",
+          "account_id": "[source_address]",
+          "sequence": "39136008289124358",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "9099.9999400",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "[source_address]",
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Mon, 10 Sep 2018 13:43:49 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAAAHAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAUmq2RtQGuBwYKjA%2FEtUHJrO2kOyQohEGjviLLi%2FqQCkAAAAAO5rKAAAAAAAAAAABKATZaAAAAEDcyTeZ%2F%2FdjeRzOKuddGlLPEE3HmKqA01CT7%2BOLmk8xUf1yQuZ6hpXQCJeeNk8Ie43z%2Busrzy6UaXPjUBAH8T0K
+    headers:
+      User-Agent:
+      - Faraday v0.15.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 10 Sep 2018 13:43:52 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dea0583011b7ca078d495b6a7f1b673691536587029; expires=Tue, 10-Sep-19
+        13:43:49 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17189'
+      X-Ratelimit-Reset:
+      - '3461'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 45825367ca08998b-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/2e507dc5f89a61ddd75d1041defd77739bb389d057b52d40b77304d41fb4d8ef"
+            }
+          },
+          "hash": "2e507dc5f89a61ddd75d1041defd77739bb389d057b52d40b77304d41fb4d8ef",
+          "ledger": 10982803,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAAAHAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAUmq2RtQGuBwYKjA/EtUHJrO2kOyQohEGjviLLi/qQCkAAAAAO5rKAAAAAAAAAAABKATZaAAAAEDcyTeZ//djeRzOKuddGlLPEE3HmKqA01CT7+OLmk8xUf1yQuZ6hpXQCJeeNk8Ie43z+usrzy6UaXPjUBAH8T0K",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAKeVkwAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAVMAXLRACLCf4AAAAGAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAKeVkwAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAVMAXLRACLCf4AAAAHAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAp5WTAAAAAAAAAABSarZG1Aa4HBgqMD8S1Qcms7aQ7JCiEQaO+IsuL+pAKQAAAAA7msoAAKeVkwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAp5WTAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABUwBctEAIsJ/gAAAAcAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAp5WTAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABT0awFEAIsJ/gAAAAcAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Mon, 10 Sep 2018 13:43:52 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 10 Sep 2018 13:43:53 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=deb71f0eaf0647a433b1edfe2598f34c91536587033; expires=Tue, 10-Sep-19
+        13:43:53 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17191'
+      X-Ratelimit-Reset:
+      - '3455'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4582537d3a2d998b-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "paging_token": "",
+          "account_id": "[source_address]",
+          "sequence": "39136008289124359",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "8999.9999300",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "[source_address]",
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Mon, 10 Sep 2018 13:43:53 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAAAIAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAsbEeNGGlT07C%2FduCprnVzN1MEe3ugnaZegKNSXN%2BsToAAAAAO5rKAAAAAAAAAAABKATZaAAAAEAiEY6MoIP5g1l0I0PU24EORhVlBOQyvo8Kb%2BiC8Wg%2FO5vbKkyQxfIYH1ATgSmtbcjwp7aHKzG1XwPZoP3IqSYP
+    headers:
+      User-Agent:
+      - Faraday v0.15.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 10 Sep 2018 13:43:57 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d6d9b4004ae799ee8dc8fba1e9012faf91536587034; expires=Tue, 10-Sep-19
+        13:43:54 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17190'
+      X-Ratelimit-Reset:
+      - '3454'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4582538478a79997-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/2d9d893c26cbde9cf86d1cca05542881b4fbe84d4e1de611f951a67c6a386200"
+            }
+          },
+          "hash": "2d9d893c26cbde9cf86d1cca05542881b4fbe84d4e1de611f951a67c6a386200",
+          "ledger": 10982804,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAAAIAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAsbEeNGGlT07C/duCprnVzN1MEe3ugnaZegKNSXN+sToAAAAAO5rKAAAAAAAAAAABKATZaAAAAEAiEY6MoIP5g1l0I0PU24EORhVlBOQyvo8Kb+iC8Wg/O5vbKkyQxfIYH1ATgSmtbcjwp7aHKzG1XwPZoP3IqSYP",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAKeVlAAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAU9GsA4ACLCf4AAAAHAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAKeVlAAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAU9GsA4ACLCf4AAAAIAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAp5WUAAAAAAAAAACxsR40YaVPTsL924KmudXM3UwR7e6Cdpl6Ao1Jc36xOgAAAAA7msoAAKeVlAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAp5WUAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABT0awDgAIsJ/gAAAAgAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAp5WUAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABS40DbgAIsJ/gAAAAgAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Mon, 10 Sep 2018 13:43:57 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 10 Sep 2018 13:43:58 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=da825e94f9d1b3b3a4f22852acf31dade1536587038; expires=Tue, 10-Sep-19
+        13:43:58 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17188'
+      X-Ratelimit-Reset:
+      - '3453'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4582539c6a4422b2-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX",
+          "paging_token": "",
+          "account_id": "GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX",
+          "sequence": "47170783998377984",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "100.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX",
+              "weight": 1,
+              "key": "GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Mon, 10 Sep 2018 13:43:58 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAALGxHjRhpU9Owv3bgqa51czdTBHt7oJ2mXoCjUlzfrE6AAAAZACnlZQAAAABAAAAAAAAAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa%2FVa29KATZaAAAAAEAAAAAUmq2RtQGuBwYKjA%2FEtUHJrO2kOyQohEGjviLLi%2FqQCkAAAAAAAAAAFloLwAAAAAAAAAAAnN%2BsToAAABAiD3rwskI7ViJTDt2sD1deW6owPk3bOX9aR97h%2BY7tW53DH8tmO3nhUT17ZoIDPE1xtrJHw2l6d%2B430iWTga9DigE2WgAAABAk3kfcpy%2FtC20wNEKSIx03TNVQoqJkMmsAcl5ji%2BJmKxenVoRAaYFzVNRcNnvdZF1JMxpxyQRgAAhhF3BSqVBCA%3D%3D
+    headers:
+      User-Agent:
+      - Faraday v0.15.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 10 Sep 2018 13:44:02 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dd3050cee91a238cb7c711e152a7e85931536587039; expires=Tue, 10-Sep-19
+        13:43:59 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17189'
+      X-Ratelimit-Reset:
+      - '3449'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 458253a4fd1f997f-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/6f6e33764ac7a15bd96ca16c0160d62a741e0df6bf689f5a56225d1f7defdc68"
+            }
+          },
+          "hash": "6f6e33764ac7a15bd96ca16c0160d62a741e0df6bf689f5a56225d1f7defdc68",
+          "ledger": 10982805,
+          "envelope_xdr": "AAAAALGxHjRhpU9Owv3bgqa51czdTBHt7oJ2mXoCjUlzfrE6AAAAZACnlZQAAAABAAAAAAAAAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAAEAAAAAUmq2RtQGuBwYKjA/EtUHJrO2kOyQohEGjviLLi/qQCkAAAAAAAAAAFloLwAAAAAAAAAAAnN+sToAAABAiD3rwskI7ViJTDt2sD1deW6owPk3bOX9aR97h+Y7tW53DH8tmO3nhUT17ZoIDPE1xtrJHw2l6d+430iWTga9DigE2WgAAABAk3kfcpy/tC20wNEKSIx03TNVQoqJkMmsAcl5ji+JmKxenVoRAaYFzVNRcNnvdZF1JMxpxyQRgAAhhF3BSqVBCA==",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAKeVlQAAAAAAAAAAsbEeNGGlT07C/duCprnVzN1MEe3ugnaZegKNSXN+sToAAAAAO5rJnACnlZQAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAKeVlQAAAAAAAAAAsbEeNGGlT07C/duCprnVzN1MEe3ugnaZegKNSXN+sToAAAAAO5rJnACnlZQAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMAp5WTAAAAAAAAAABSarZG1Aa4HBgqMD8S1Qcms7aQ7JCiEQaO+IsuL+pAKQAAAAA7msoAAKeVkwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAp5WVAAAAAAAAAABSarZG1Aa4HBgqMD8S1Qcms7aQ7JCiEQaO+IsuL+pAKQAAAACVAvkAAKeVkwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAp5WUAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABS40DbgAIsJ/gAAAAgAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAp5WVAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABRfaAfgAIsJ/gAAAAgAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Mon, 10 Sep 2018 13:44:02 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 10 Sep 2018 13:44:03 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dd2a3e2cb192ec9ec9a49ddb036a6a86c1536587042; expires=Tue, 10-Sep-19
+        13:44:02 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17187'
+      X-Ratelimit-Reset:
+      - '3448'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 458253ba5e5f997f-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5",
+          "paging_token": "",
+          "account_id": "GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5",
+          "sequence": "47170779703410688",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "250.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5",
+              "weight": 1,
+              "key": "GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Mon, 10 Sep 2018 13:44:03 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Stellar_Client/_send_payment/native_asset/sends_a_native_payment_to_the_account_through_a_channel_account.yml
+++ b/spec/fixtures/vcr_cassettes/Stellar_Client/_send_payment/native_asset/sends_a_native_payment_to_the_account_through_a_channel_account.yml
@@ -17,14 +17,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 12 Sep 2018 16:02:54 GMT
+      - Thu, 13 Sep 2018 09:38:34 GMT
       Content-Type:
       - application/hal+json; charset=utf-8
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=d7601fb4b0211c9b3695d8de0db0a87461536768174; expires=Thu, 12-Sep-19
-        16:02:54 GMT; path=/; domain=.stellar.org; HttpOnly
+      - __cfduid=de5bda3e7d13924e5be07ffba2dbe5c5e1536831513; expires=Fri, 13-Sep-19
+        09:38:33 GMT; path=/; domain=.stellar.org; HttpOnly
       Cache-Control:
       - no-cache, no-store, max-age=0
       Content-Disposition:
@@ -34,15 +34,15 @@ http_interactions:
       X-Ratelimit-Limit:
       - '17200'
       X-Ratelimit-Remaining:
-      - '17145'
+      - '17138'
       X-Ratelimit-Reset:
-      - '621'
+      - '1086'
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Server:
       - cloudflare
       Cf-Ray:
-      - 459399e09cad77ae-LAX
+      - 4599a43e9e87a9b4-SIN
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -85,14 +85,14 @@ http_interactions:
           },
           "horizon_version": "0.14.0-81f12a7e313bc469b229cd89c7843a7fc1db9403",
           "core_version": "stellar-core 10.0.0 (1fc018b4f52e8c7e716b023ccf30600af5b4f66d)",
-          "history_latest_ledger": 11017956,
+          "history_latest_ledger": 11030263,
           "history_elder_ledger": 1,
-          "core_latest_ledger": 11017956,
+          "core_latest_ledger": 11030264,
           "network_passphrase": "Test SDF Network ; September 2015",
           "protocol_version": 10
         }
     http_version: 
-  recorded_at: Wed, 12 Sep 2018 16:02:54 GMT
+  recorded_at: Thu, 13 Sep 2018 09:38:34 GMT
 - request:
     method: get
     uri: https://horizon-testnet.stellar.org/accounts/[source_address]
@@ -110,14 +110,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 12 Sep 2018 16:02:55 GMT
+      - Thu, 13 Sep 2018 09:38:36 GMT
       Content-Type:
       - application/hal+json; charset=utf-8
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=dee20cf279cf29e1c28f51f5b886f81291536768175; expires=Thu, 12-Sep-19
-        16:02:55 GMT; path=/; domain=.stellar.org; HttpOnly
+      - __cfduid=d20a982bffc82e3288369bfedb3bec5371536831515; expires=Fri, 13-Sep-19
+        09:38:35 GMT; path=/; domain=.stellar.org; HttpOnly
       Cache-Control:
       - no-cache, no-store, max-age=0
       Content-Disposition:
@@ -127,15 +127,15 @@ http_interactions:
       X-Ratelimit-Limit:
       - '17200'
       X-Ratelimit-Remaining:
-      - '17146'
+      - '17137'
       X-Ratelimit-Reset:
-      - '621'
+      - '1085'
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Server:
       - cloudflare
       Cf-Ray:
-      - 459399e7aa249985-LAX
+      - 4599a44afd208466-HKG
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -176,7 +176,7 @@ http_interactions:
           "id": "[source_address]",
           "paging_token": "",
           "account_id": "[source_address]",
-          "sequence": "39136008289124443",
+          "sequence": "39136008289124476",
           "subentry_count": 0,
           "thresholds": {
             "low_threshold": 0,
@@ -189,7 +189,7 @@ http_interactions:
           },
           "balances": [
             {
-              "balance": "99.9990900",
+              "balance": "13549.9987600",
               "buying_liabilities": "0.0000000",
               "selling_liabilities": "0.0000000",
               "asset_type": "native"
@@ -206,13 +206,13 @@ http_interactions:
           "data": {}
         }
     http_version: 
-  recorded_at: Wed, 12 Sep 2018 16:02:55 GMT
+  recorded_at: Thu, 13 Sep 2018 09:38:36 GMT
 - request:
     method: post
     uri: https://horizon-testnet.stellar.org/transactions
     body:
       encoding: UTF-8
-      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAABcAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAuHhhDFKc4kbOYilqk3u4L33FHzI94V6YBqGVsxCF8fMAAAAAO5rKAAAAAAAAAAABKATZaAAAAECL8sAn%2FF7SZpY76zaPL%2F9yoqiLpbdThESCpjVQFKtsYk0IRz2%2B%2B5FnsRkYLt1JizmQPCAj2QcZMudQg2j6%2BLEI
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAAB9AAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAyDewhFMeMMmFwgiw5si1dtFrdrxenZGomZTbF528us0AAAAAO5rKAAAAAAAAAAABKATZaAAAAEByG8mTuAmzK7TAwWTCoGUtCVXZyQ0x8iZmHMYW2EmSErIBlBS269NG8UefvphsJLnCqCnZMoAVnVG4QPuA0RoD
     headers:
       User-Agent:
       - Faraday v0.15.2
@@ -222,55 +222,705 @@ http_interactions:
       - application/x-www-form-urlencoded
   response:
     status:
-      code: 400
-      message: Bad Request
+      code: 200
+      message: OK
     headers:
       Date:
-      - Wed, 12 Sep 2018 16:02:59 GMT
+      - Thu, 13 Sep 2018 09:38:40 GMT
       Content-Type:
-      - application/problem+json; charset=utf-8
-      Content-Length:
-      - '871'
+      - application/hal+json; charset=utf-8
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=d43dcab860c5fd543b26866b706d7b7aa1536768176; expires=Thu, 12-Sep-19
-        16:02:56 GMT; path=/; domain=.stellar.org; HttpOnly
+      - __cfduid=d49400e6b7c5510a70e8443531954b7051536831517; expires=Fri, 13-Sep-19
+        09:38:37 GMT; path=/; domain=.stellar.org; HttpOnly
       Cache-Control:
       - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
       Vary:
       - Origin
       X-Ratelimit-Limit:
       - '17200'
       X-Ratelimit-Remaining:
-      - '17145'
+      - '17127'
       X-Ratelimit-Reset:
-      - '619'
+      - '1082'
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Server:
       - cloudflare
       Cf-Ray:
-      - 459399eee8c299a3-LAX
+      - 4599a457eb6a855c-HKG
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "type": "https://stellar.org/horizon-errors/transaction_failed",
-          "title": "Transaction Failed",
-          "status": 400,
-          "detail": "The transaction failed when submitted to the stellar network. The `extras.result_codes` field on this response contains further details.  Descriptions of each code can be found at: https://www.stellar.org/developers/learn/concepts/list-of-operations.html",
-          "extras": {
-            "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAABcAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAuHhhDFKc4kbOYilqk3u4L33FHzI94V6YBqGVsxCF8fMAAAAAO5rKAAAAAAAAAAABKATZaAAAAECL8sAn/F7SZpY76zaPL/9yoqiLpbdThESCpjVQFKtsYk0IRz2++5FnsRkYLt1JizmQPCAj2QcZMudQg2j6+LEI",
-            "result_codes": {
-              "transaction": "tx_failed",
-              "operations": [
-                "op_underfunded"
-              ]
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/9a9fa569aff5e10355453ede697cdffd7d1b14e98555e8220a702c1b0322e902"
+            }
+          },
+          "hash": "9a9fa569aff5e10355453ede697cdffd7d1b14e98555e8220a702c1b0322e902",
+          "ledger": 11030265,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAAB9AAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAyDewhFMeMMmFwgiw5si1dtFrdrxenZGomZTbF528us0AAAAAO5rKAAAAAAAAAAABKATZaAAAAEByG8mTuAmzK7TAwWTCoGUtCVXZyQ0x8iZmHMYW2EmSErIBlBS269NG8UefvphsJLnCqCnZMoAVnVG4QPuA0RoD",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAKhO+QAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAfjG26LACLCf4AAAB8AAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAKhO+QAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAfjG26LACLCf4AAAB9AAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAqE75AAAAAAAAAADIN7CEUx4wyYXCCLDmyLV20Wt2vF6dkaiZlNsXnby6zQAAAAA7msoAAKhO+QAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAqE75AAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAB+MbbosAIsJ/gAAAH0AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAqE75AAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAB9Q0vAsAIsJ/gAAAH0AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Thu, 13 Sep 2018 09:38:40 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 13 Sep 2018 09:38:42 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d34faf77c0e7c4c0ec27d64d9933874cc1536831521; expires=Fri, 13-Sep-19
+        09:38:41 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17136'
+      X-Ratelimit-Reset:
+      - '1078'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4599a473484c8520-HKG
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
             },
-            "result_xdr": "AAAAAAAAAGT/////AAAAAQAAAAAAAAAA/////gAAAAA="
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "paging_token": "",
+          "account_id": "[source_address]",
+          "sequence": "39136008289124477",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "13449.9987500",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "[source_address]",
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Thu, 13 Sep 2018 09:38:42 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAAB%2BAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAMiByLjAtp4stA4yey4N3lLhN05WzWphBGy04rPBPJPMAAAACVAvkAAAAAAAAAAABKATZaAAAAECbgkKOyeGwYdfba0zOEJEjDCMoWWtOcBu3OJPRhkTf8wjJ6%2BGRqKu7p6J6yqLyTOIao37P%2FV35N%2BQ2owytoKcK
+    headers:
+      User-Agent:
+      - Faraday v0.15.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 13 Sep 2018 09:38:46 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d16d162fdde250692f83fe64550ca14021536831523; expires=Fri, 13-Sep-19
+        09:38:43 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17126'
+      X-Ratelimit-Reset:
+      - '1076'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4599a47d2f9184ba-HKG
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/3ae28a23fb03029995b313ce9a2b258db764e75183920976581e2be117366127"
+            }
+          },
+          "hash": "3ae28a23fb03029995b313ce9a2b258db764e75183920976581e2be117366127",
+          "ledger": 11030266,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAAB+AAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAMiByLjAtp4stA4yey4N3lLhN05WzWphBGy04rPBPJPMAAAACVAvkAAAAAAAAAAABKATZaAAAAECbgkKOyeGwYdfba0zOEJEjDCMoWWtOcBu3OJPRhkTf8wjJ6+GRqKu7p6J6yqLyTOIao37P/V35N+Q2owytoKcK",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAKhO+gAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAfUNLvyACLCf4AAAB9AAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAKhO+gAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAfUNLvyACLCf4AAAB+AAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAqE76AAAAAAAAAAAyIHIuMC2niy0DjJ7Lg3eUuE3TlbNamEEbLTis8E8k8wAAAAJUC+QAAKhO+gAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAqE76AAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAB9Q0u/IAIsJ/gAAAH4AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAqE76AAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABz8xwvIAIsJ/gAAAH4AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Thu, 13 Sep 2018 09:38:46 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GAZCA4ROGAW2PCZNAOGJ5S4DO6KLQTOTSWZVVGCBDMWTRLHQJ4SPHKZN
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 13 Sep 2018 09:38:48 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d8572d8ecdfb0a933fb58ec3b84a181c01536831527; expires=Fri, 13-Sep-19
+        09:38:47 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17125'
+      X-Ratelimit-Reset:
+      - '1072'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4599a494cffc84c6-HKG
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAZCA4ROGAW2PCZNAOGJ5S4DO6KLQTOTSWZVVGCBDMWTRLHQJ4SPHKZN"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAZCA4ROGAW2PCZNAOGJ5S4DO6KLQTOTSWZVVGCBDMWTRLHQJ4SPHKZN/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAZCA4ROGAW2PCZNAOGJ5S4DO6KLQTOTSWZVVGCBDMWTRLHQJ4SPHKZN/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAZCA4ROGAW2PCZNAOGJ5S4DO6KLQTOTSWZVVGCBDMWTRLHQJ4SPHKZN/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAZCA4ROGAW2PCZNAOGJ5S4DO6KLQTOTSWZVVGCBDMWTRLHQJ4SPHKZN/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAZCA4ROGAW2PCZNAOGJ5S4DO6KLQTOTSWZVVGCBDMWTRLHQJ4SPHKZN/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAZCA4ROGAW2PCZNAOGJ5S4DO6KLQTOTSWZVVGCBDMWTRLHQJ4SPHKZN/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAZCA4ROGAW2PCZNAOGJ5S4DO6KLQTOTSWZVVGCBDMWTRLHQJ4SPHKZN/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GAZCA4ROGAW2PCZNAOGJ5S4DO6KLQTOTSWZVVGCBDMWTRLHQJ4SPHKZN",
+          "paging_token": "",
+          "account_id": "GAZCA4ROGAW2PCZNAOGJ5S4DO6KLQTOTSWZVVGCBDMWTRLHQJ4SPHKZN",
+          "sequence": "47374631736180736",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "1000.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GAZCA4ROGAW2PCZNAOGJ5S4DO6KLQTOTSWZVVGCBDMWTRLHQJ4SPHKZN",
+              "weight": 1,
+              "key": "GAZCA4ROGAW2PCZNAOGJ5S4DO6KLQTOTSWZVVGCBDMWTRLHQJ4SPHKZN",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Thu, 13 Sep 2018 09:38:48 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAADIgci4wLaeLLQOMnsuDd5S4TdOVs1qYQRstOKzwTyTzAAAAZACoTvoAAAABAAAAAAAAAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa%2FVa29KATZaAAAAAEAAAAAyDewhFMeMMmFwgiw5si1dtFrdrxenZGomZTbF528us0AAAAAAAAAAFloLwAAAAAAAAAAAvBPJPMAAABAIIWhWhlaJwiwWCzth4ExQU%2BLpMH7c8ceaxfpX1jtkWEdtii23SvztIIfnnHoANW4S2IeWaqoe2LLXMVwsS5ZACgE2WgAAABAqOnzizSr0%2F7Yq5SY8eH3VI5v44qiKdiaTKlbzG0CVeAoVmeho1z6Fji8u9lgLQpzphFY8qJqLhfnS45FSa1SBA%3D%3D
+    headers:
+      User-Agent:
+      - Faraday v0.15.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 13 Sep 2018 09:38:51 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d1c55bc9146e6cb87ed55c449ab54f9841536831528; expires=Fri, 13-Sep-19
+        09:38:48 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17124'
+      X-Ratelimit-Reset:
+      - '1071'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4599a49e38a4a978-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/86c6cdf5c69d9d6a575174e5b7b80c5977a645deb3a9422e5b424b56546108e2"
+            }
+          },
+          "hash": "86c6cdf5c69d9d6a575174e5b7b80c5977a645deb3a9422e5b424b56546108e2",
+          "ledger": 11030267,
+          "envelope_xdr": "AAAAADIgci4wLaeLLQOMnsuDd5S4TdOVs1qYQRstOKzwTyTzAAAAZACoTvoAAAABAAAAAAAAAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAAEAAAAAyDewhFMeMMmFwgiw5si1dtFrdrxenZGomZTbF528us0AAAAAAAAAAFloLwAAAAAAAAAAAvBPJPMAAABAIIWhWhlaJwiwWCzth4ExQU+LpMH7c8ceaxfpX1jtkWEdtii23SvztIIfnnHoANW4S2IeWaqoe2LLXMVwsS5ZACgE2WgAAABAqOnzizSr0/7Yq5SY8eH3VI5v44qiKdiaTKlbzG0CVeAoVmeho1z6Fji8u9lgLQpzphFY8qJqLhfnS45FSa1SBA==",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAKhO+wAAAAAAAAAAMiByLjAtp4stA4yey4N3lLhN05WzWphBGy04rPBPJPMAAAACVAvjnACoTvoAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAKhO+wAAAAAAAAAAMiByLjAtp4stA4yey4N3lLhN05WzWphBGy04rPBPJPMAAAACVAvjnACoTvoAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMAqE76AAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABz8xwvIAIsJ/gAAAH4AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAqE77AAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAByjXtzIAIsJ/gAAAH4AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAqE75AAAAAAAAAADIN7CEUx4wyYXCCLDmyLV20Wt2vF6dkaiZlNsXnby6zQAAAAA7msoAAKhO+QAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAqE77AAAAAAAAAADIN7CEUx4wyYXCCLDmyLV20Wt2vF6dkaiZlNsXnby6zQAAAACVAvkAAKhO+QAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Thu, 13 Sep 2018 09:38:51 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/transactions/86c6cdf5c69d9d6a575174e5b7b80c5977a645deb3a9422e5b424b56546108e2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 13 Sep 2018 09:38:52 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d2393bec2713c4fcbc1c59785cdd8c2051536831531; expires=Fri, 13-Sep-19
+        09:38:51 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17135'
+      X-Ratelimit-Reset:
+      - '1068'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4599a4b288d2a8fa-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/transactions/86c6cdf5c69d9d6a575174e5b7b80c5977a645deb3a9422e5b424b56546108e2"
+            },
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAZCA4ROGAW2PCZNAOGJ5S4DO6KLQTOTSWZVVGCBDMWTRLHQJ4SPHKZN"
+            },
+            "ledger": {
+              "href": "https://horizon-testnet.stellar.org/ledgers/11030267"
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/transactions/86c6cdf5c69d9d6a575174e5b7b80c5977a645deb3a9422e5b424b56546108e2/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/transactions/86c6cdf5c69d9d6a575174e5b7b80c5977a645deb3a9422e5b424b56546108e2/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "precedes": {
+              "href": "https://horizon-testnet.stellar.org/transactions?order=asc\u0026cursor=47374636031152128"
+            },
+            "succeeds": {
+              "href": "https://horizon-testnet.stellar.org/transactions?order=desc\u0026cursor=47374636031152128"
+            }
+          },
+          "id": "86c6cdf5c69d9d6a575174e5b7b80c5977a645deb3a9422e5b424b56546108e2",
+          "paging_token": "47374636031152128",
+          "hash": "86c6cdf5c69d9d6a575174e5b7b80c5977a645deb3a9422e5b424b56546108e2",
+          "ledger": 11030267,
+          "created_at": "2018-09-13T09:38:50Z",
+          "source_account": "GAZCA4ROGAW2PCZNAOGJ5S4DO6KLQTOTSWZVVGCBDMWTRLHQJ4SPHKZN",
+          "source_account_sequence": "47374631736180737",
+          "fee_paid": 100,
+          "operation_count": 1,
+          "envelope_xdr": "AAAAADIgci4wLaeLLQOMnsuDd5S4TdOVs1qYQRstOKzwTyTzAAAAZACoTvoAAAABAAAAAAAAAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAAEAAAAAyDewhFMeMMmFwgiw5si1dtFrdrxenZGomZTbF528us0AAAAAAAAAAFloLwAAAAAAAAAAAvBPJPMAAABAIIWhWhlaJwiwWCzth4ExQU+LpMH7c8ceaxfpX1jtkWEdtii23SvztIIfnnHoANW4S2IeWaqoe2LLXMVwsS5ZACgE2WgAAABAqOnzizSr0/7Yq5SY8eH3VI5v44qiKdiaTKlbzG0CVeAoVmeho1z6Fji8u9lgLQpzphFY8qJqLhfnS45FSa1SBA==",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAKhO+wAAAAAAAAAAMiByLjAtp4stA4yey4N3lLhN05WzWphBGy04rPBPJPMAAAACVAvjnACoTvoAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAKhO+wAAAAAAAAAAMiByLjAtp4stA4yey4N3lLhN05WzWphBGy04rPBPJPMAAAACVAvjnACoTvoAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMAqE76AAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABz8xwvIAIsJ/gAAAH4AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAqE77AAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAByjXtzIAIsJ/gAAAH4AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAqE75AAAAAAAAAADIN7CEUx4wyYXCCLDmyLV20Wt2vF6dkaiZlNsXnby6zQAAAAA7msoAAKhO+QAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAqE77AAAAAAAAAADIN7CEUx4wyYXCCLDmyLV20Wt2vF6dkaiZlNsXnby6zQAAAACVAvkAAKhO+QAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+          "fee_meta_xdr": "AAAAAgAAAAMAqE76AAAAAAAAAAAyIHIuMC2niy0DjJ7Lg3eUuE3TlbNamEEbLTis8E8k8wAAAAJUC+QAAKhO+gAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAqE77AAAAAAAAAAAyIHIuMC2niy0DjJ7Lg3eUuE3TlbNamEEbLTis8E8k8wAAAAJUC+OcAKhO+gAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+          "memo_type": "none",
+          "signatures": [
+            "IIWhWhlaJwiwWCzth4ExQU+LpMH7c8ceaxfpX1jtkWEdtii23SvztIIfnnHoANW4S2IeWaqoe2LLXMVwsS5ZAA==",
+            "qOnzizSr0/7Yq5SY8eH3VI5v44qiKdiaTKlbzG0CVeAoVmeho1z6Fji8u9lgLQpzphFY8qJqLhfnS45FSa1SBA=="
+          ]
+        }
+    http_version: 
+  recorded_at: Thu, 13 Sep 2018 09:38:53 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/transactions/86c6cdf5c69d9d6a575174e5b7b80c5977a645deb3a9422e5b424b56546108e2/operations
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 13 Sep 2018 09:38:55 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d40fc2f9630afe628752df8c1e3493b2f1536831534; expires=Fri, 13-Sep-19
+        09:38:54 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17134'
+      X-Ratelimit-Reset:
+      - '1066'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4599a4c23ec0a95a-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/transactions/86c6cdf5c69d9d6a575174e5b7b80c5977a645deb3a9422e5b424b56546108e2/operations?cursor=\u0026limit=10\u0026order=asc"
+            },
+            "next": {
+              "href": "https://horizon-testnet.stellar.org/transactions/86c6cdf5c69d9d6a575174e5b7b80c5977a645deb3a9422e5b424b56546108e2/operations?cursor=47374636031152129\u0026limit=10\u0026order=asc"
+            },
+            "prev": {
+              "href": "https://horizon-testnet.stellar.org/transactions/86c6cdf5c69d9d6a575174e5b7b80c5977a645deb3a9422e5b424b56546108e2/operations?cursor=47374636031152129\u0026limit=10\u0026order=desc"
+            }
+          },
+          "_embedded": {
+            "records": [
+              {
+                "_links": {
+                  "self": {
+                    "href": "https://horizon-testnet.stellar.org/operations/47374636031152129"
+                  },
+                  "transaction": {
+                    "href": "https://horizon-testnet.stellar.org/transactions/86c6cdf5c69d9d6a575174e5b7b80c5977a645deb3a9422e5b424b56546108e2"
+                  },
+                  "effects": {
+                    "href": "https://horizon-testnet.stellar.org/operations/47374636031152129/effects"
+                  },
+                  "succeeds": {
+                    "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=47374636031152129"
+                  },
+                  "precedes": {
+                    "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=47374636031152129"
+                  }
+                },
+                "id": "47374636031152129",
+                "paging_token": "47374636031152129",
+                "source_account": "[source_address]",
+                "type": "payment",
+                "type_i": 1,
+                "created_at": "2018-09-13T09:38:50Z",
+                "transaction_hash": "86c6cdf5c69d9d6a575174e5b7b80c5977a645deb3a9422e5b424b56546108e2",
+                "asset_type": "native",
+                "from": "[source_address]",
+                "to": "GDEDPMEEKMPDBSMFYIELBZWIWV3NC23WXRPJ3ENITGKNWF45XS5M2YWA",
+                "amount": "150.0000000"
+              }
+            ]
           }
         }
     http_version: 
-  recorded_at: Wed, 12 Sep 2018 16:02:59 GMT
+  recorded_at: Thu, 13 Sep 2018 09:38:55 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GDEDPMEEKMPDBSMFYIELBZWIWV3NC23WXRPJ3ENITGKNWF45XS5M2YWA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 13 Sep 2018 09:38:57 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=df4c76214cf2c15db76bc4d47ededd0d51536831536; expires=Fri, 13-Sep-19
+        09:38:56 GMT; path=/; domain=.stellar.org; HttpOnly
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17133'
+      X-Ratelimit-Reset:
+      - '1064'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4599a4ce7eee84d2-HKG
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDEDPMEEKMPDBSMFYIELBZWIWV3NC23WXRPJ3ENITGKNWF45XS5M2YWA"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDEDPMEEKMPDBSMFYIELBZWIWV3NC23WXRPJ3ENITGKNWF45XS5M2YWA/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDEDPMEEKMPDBSMFYIELBZWIWV3NC23WXRPJ3ENITGKNWF45XS5M2YWA/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDEDPMEEKMPDBSMFYIELBZWIWV3NC23WXRPJ3ENITGKNWF45XS5M2YWA/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDEDPMEEKMPDBSMFYIELBZWIWV3NC23WXRPJ3ENITGKNWF45XS5M2YWA/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDEDPMEEKMPDBSMFYIELBZWIWV3NC23WXRPJ3ENITGKNWF45XS5M2YWA/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDEDPMEEKMPDBSMFYIELBZWIWV3NC23WXRPJ3ENITGKNWF45XS5M2YWA/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDEDPMEEKMPDBSMFYIELBZWIWV3NC23WXRPJ3ENITGKNWF45XS5M2YWA/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GDEDPMEEKMPDBSMFYIELBZWIWV3NC23WXRPJ3ENITGKNWF45XS5M2YWA",
+          "paging_token": "",
+          "account_id": "GDEDPMEEKMPDBSMFYIELBZWIWV3NC23WXRPJ3ENITGKNWF45XS5M2YWA",
+          "sequence": "47374627441213440",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "250.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GDEDPMEEKMPDBSMFYIELBZWIWV3NC23WXRPJ3ENITGKNWF45XS5M2YWA",
+              "weight": 1,
+              "key": "GDEDPMEEKMPDBSMFYIELBZWIWV3NC23WXRPJ3ENITGKNWF45XS5M2YWA",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Thu, 13 Sep 2018 09:38:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Stellar_Client/_send_payment/native_asset/sends_a_native_payment_to_the_account_through_a_channel_account.yml
+++ b/spec/fixtures/vcr_cassettes/Stellar_Client/_send_payment/native_asset/sends_a_native_payment_to_the_account_through_a_channel_account.yml
@@ -17,14 +17,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 10 Sep 2018 13:43:47 GMT
+      - Wed, 12 Sep 2018 16:02:54 GMT
       Content-Type:
       - application/hal+json; charset=utf-8
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=dee2e445b2ae53bcadc9d543367c063ed1536587027; expires=Tue, 10-Sep-19
-        13:43:47 GMT; path=/; domain=.stellar.org; HttpOnly
+      - __cfduid=d7601fb4b0211c9b3695d8de0db0a87461536768174; expires=Thu, 12-Sep-19
+        16:02:54 GMT; path=/; domain=.stellar.org; HttpOnly
       Cache-Control:
       - no-cache, no-store, max-age=0
       Content-Disposition:
@@ -34,15 +34,15 @@ http_interactions:
       X-Ratelimit-Limit:
       - '17200'
       X-Ratelimit-Remaining:
-      - '17190'
+      - '17145'
       X-Ratelimit-Reset:
-      - '3464'
+      - '621'
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Server:
       - cloudflare
       Cf-Ray:
-      - 4582535959d19901-LAX
+      - 459399e09cad77ae-LAX
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -85,14 +85,14 @@ http_interactions:
           },
           "horizon_version": "0.14.0-81f12a7e313bc469b229cd89c7843a7fc1db9403",
           "core_version": "stellar-core 10.0.0 (1fc018b4f52e8c7e716b023ccf30600af5b4f66d)",
-          "history_latest_ledger": 10982802,
+          "history_latest_ledger": 11017956,
           "history_elder_ledger": 1,
-          "core_latest_ledger": 10982802,
+          "core_latest_ledger": 11017956,
           "network_passphrase": "Test SDF Network ; September 2015",
           "protocol_version": 10
         }
     http_version: 
-  recorded_at: Mon, 10 Sep 2018 13:43:47 GMT
+  recorded_at: Wed, 12 Sep 2018 16:02:54 GMT
 - request:
     method: get
     uri: https://horizon-testnet.stellar.org/accounts/[source_address]
@@ -110,14 +110,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 10 Sep 2018 13:43:48 GMT
+      - Wed, 12 Sep 2018 16:02:55 GMT
       Content-Type:
       - application/hal+json; charset=utf-8
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=d32eeb89fb81a67f6d8c790c4c9c5cfd31536587028; expires=Tue, 10-Sep-19
-        13:43:48 GMT; path=/; domain=.stellar.org; HttpOnly
+      - __cfduid=dee20cf279cf29e1c28f51f5b886f81291536768175; expires=Thu, 12-Sep-19
+        16:02:55 GMT; path=/; domain=.stellar.org; HttpOnly
       Cache-Control:
       - no-cache, no-store, max-age=0
       Content-Disposition:
@@ -127,15 +127,15 @@ http_interactions:
       X-Ratelimit-Limit:
       - '17200'
       X-Ratelimit-Remaining:
-      - '17192'
+      - '17146'
       X-Ratelimit-Reset:
-      - '3460'
+      - '621'
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Server:
       - cloudflare
       Cf-Ray:
-      - 458253608ea69901-LAX
+      - 459399e7aa249985-LAX
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -176,7 +176,7 @@ http_interactions:
           "id": "[source_address]",
           "paging_token": "",
           "account_id": "[source_address]",
-          "sequence": "39136008289124358",
+          "sequence": "39136008289124443",
           "subentry_count": 0,
           "thresholds": {
             "low_threshold": 0,
@@ -189,7 +189,7 @@ http_interactions:
           },
           "balances": [
             {
-              "balance": "9099.9999400",
+              "balance": "99.9990900",
               "buying_liabilities": "0.0000000",
               "selling_liabilities": "0.0000000",
               "asset_type": "native"
@@ -206,13 +206,13 @@ http_interactions:
           "data": {}
         }
     http_version: 
-  recorded_at: Mon, 10 Sep 2018 13:43:49 GMT
+  recorded_at: Wed, 12 Sep 2018 16:02:55 GMT
 - request:
     method: post
     uri: https://horizon-testnet.stellar.org/transactions
     body:
       encoding: UTF-8
-      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAAAHAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAUmq2RtQGuBwYKjA%2FEtUHJrO2kOyQohEGjviLLi%2FqQCkAAAAAO5rKAAAAAAAAAAABKATZaAAAAEDcyTeZ%2F%2FdjeRzOKuddGlLPEE3HmKqA01CT7%2BOLmk8xUf1yQuZ6hpXQCJeeNk8Ie43z%2Busrzy6UaXPjUBAH8T0K
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAABcAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAuHhhDFKc4kbOYilqk3u4L33FHzI94V6YBqGVsxCF8fMAAAAAO5rKAAAAAAAAAAABKATZaAAAAECL8sAn%2FF7SZpY76zaPL%2F9yoqiLpbdThESCpjVQFKtsYk0IRz2%2B%2B5FnsRkYLt1JizmQPCAj2QcZMudQg2j6%2BLEI
     headers:
       User-Agent:
       - Faraday v0.15.2
@@ -222,517 +222,55 @@ http_interactions:
       - application/x-www-form-urlencoded
   response:
     status:
-      code: 200
-      message: OK
+      code: 400
+      message: Bad Request
     headers:
       Date:
-      - Mon, 10 Sep 2018 13:43:52 GMT
+      - Wed, 12 Sep 2018 16:02:59 GMT
       Content-Type:
-      - application/hal+json; charset=utf-8
+      - application/problem+json; charset=utf-8
+      Content-Length:
+      - '871'
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=dea0583011b7ca078d495b6a7f1b673691536587029; expires=Tue, 10-Sep-19
-        13:43:49 GMT; path=/; domain=.stellar.org; HttpOnly
+      - __cfduid=d43dcab860c5fd543b26866b706d7b7aa1536768176; expires=Thu, 12-Sep-19
+        16:02:56 GMT; path=/; domain=.stellar.org; HttpOnly
       Cache-Control:
       - no-cache, no-store, max-age=0
-      Content-Disposition:
-      - inline
       Vary:
       - Origin
       X-Ratelimit-Limit:
       - '17200'
       X-Ratelimit-Remaining:
-      - '17189'
+      - '17145'
       X-Ratelimit-Reset:
-      - '3461'
+      - '619'
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Server:
       - cloudflare
       Cf-Ray:
-      - 45825367ca08998b-LAX
+      - 459399eee8c299a3-LAX
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "_links": {
-            "transaction": {
-              "href": "https://horizon-testnet.stellar.org/transactions/2e507dc5f89a61ddd75d1041defd77739bb389d057b52d40b77304d41fb4d8ef"
-            }
-          },
-          "hash": "2e507dc5f89a61ddd75d1041defd77739bb389d057b52d40b77304d41fb4d8ef",
-          "ledger": 10982803,
-          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAAAHAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAUmq2RtQGuBwYKjA/EtUHJrO2kOyQohEGjviLLi/qQCkAAAAAO5rKAAAAAAAAAAABKATZaAAAAEDcyTeZ//djeRzOKuddGlLPEE3HmKqA01CT7+OLmk8xUf1yQuZ6hpXQCJeeNk8Ie43z+usrzy6UaXPjUBAH8T0K",
-          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
-          "result_meta_xdr": "AAAAAQAAAAIAAAADAKeVkwAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAVMAXLRACLCf4AAAAGAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAKeVkwAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAVMAXLRACLCf4AAAAHAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAp5WTAAAAAAAAAABSarZG1Aa4HBgqMD8S1Qcms7aQ7JCiEQaO+IsuL+pAKQAAAAA7msoAAKeVkwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAp5WTAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABUwBctEAIsJ/gAAAAcAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAp5WTAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABT0awFEAIsJ/gAAAAcAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+          "type": "https://stellar.org/horizon-errors/transaction_failed",
+          "title": "Transaction Failed",
+          "status": 400,
+          "detail": "The transaction failed when submitted to the stellar network. The `extras.result_codes` field on this response contains further details.  Descriptions of each code can be found at: https://www.stellar.org/developers/learn/concepts/list-of-operations.html",
+          "extras": {
+            "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAABcAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAuHhhDFKc4kbOYilqk3u4L33FHzI94V6YBqGVsxCF8fMAAAAAO5rKAAAAAAAAAAABKATZaAAAAECL8sAn/F7SZpY76zaPL/9yoqiLpbdThESCpjVQFKtsYk0IRz2++5FnsRkYLt1JizmQPCAj2QcZMudQg2j6+LEI",
+            "result_codes": {
+              "transaction": "tx_failed",
+              "operations": [
+                "op_underfunded"
+              ]
+            },
+            "result_xdr": "AAAAAAAAAGT/////AAAAAQAAAAAAAAAA/////gAAAAA="
+          }
         }
     http_version: 
-  recorded_at: Mon, 10 Sep 2018 13:43:52 GMT
-- request:
-    method: get
-    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.15.2
-      Accept:
-      - application/hal+json,application/problem+json,application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 10 Sep 2018 13:43:53 GMT
-      Content-Type:
-      - application/hal+json; charset=utf-8
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - __cfduid=deb71f0eaf0647a433b1edfe2598f34c91536587033; expires=Tue, 10-Sep-19
-        13:43:53 GMT; path=/; domain=.stellar.org; HttpOnly
-      Cache-Control:
-      - no-cache, no-store, max-age=0
-      Content-Disposition:
-      - inline
-      Vary:
-      - Origin
-      X-Ratelimit-Limit:
-      - '17200'
-      X-Ratelimit-Remaining:
-      - '17191'
-      X-Ratelimit-Reset:
-      - '3455'
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 4582537d3a2d998b-LAX
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "_links": {
-            "self": {
-              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
-            },
-            "transactions": {
-              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
-              "templated": true
-            },
-            "operations": {
-              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
-              "templated": true
-            },
-            "payments": {
-              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
-              "templated": true
-            },
-            "effects": {
-              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
-              "templated": true
-            },
-            "offers": {
-              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
-              "templated": true
-            },
-            "trades": {
-              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
-              "templated": true
-            },
-            "data": {
-              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
-              "templated": true
-            }
-          },
-          "id": "[source_address]",
-          "paging_token": "",
-          "account_id": "[source_address]",
-          "sequence": "39136008289124359",
-          "subentry_count": 0,
-          "thresholds": {
-            "low_threshold": 0,
-            "med_threshold": 0,
-            "high_threshold": 0
-          },
-          "flags": {
-            "auth_required": false,
-            "auth_revocable": false
-          },
-          "balances": [
-            {
-              "balance": "8999.9999300",
-              "buying_liabilities": "0.0000000",
-              "selling_liabilities": "0.0000000",
-              "asset_type": "native"
-            }
-          ],
-          "signers": [
-            {
-              "public_key": "[source_address]",
-              "weight": 1,
-              "key": "[source_address]",
-              "type": "ed25519_public_key"
-            }
-          ],
-          "data": {}
-        }
-    http_version: 
-  recorded_at: Mon, 10 Sep 2018 13:43:53 GMT
-- request:
-    method: post
-    uri: https://horizon-testnet.stellar.org/transactions
-    body:
-      encoding: UTF-8
-      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAAAIAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAsbEeNGGlT07C%2FduCprnVzN1MEe3ugnaZegKNSXN%2BsToAAAAAO5rKAAAAAAAAAAABKATZaAAAAEAiEY6MoIP5g1l0I0PU24EORhVlBOQyvo8Kb%2BiC8Wg%2FO5vbKkyQxfIYH1ATgSmtbcjwp7aHKzG1XwPZoP3IqSYP
-    headers:
-      User-Agent:
-      - Faraday v0.15.2
-      Accept:
-      - application/hal+json,application/problem+json,application/json
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 10 Sep 2018 13:43:57 GMT
-      Content-Type:
-      - application/hal+json; charset=utf-8
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - __cfduid=d6d9b4004ae799ee8dc8fba1e9012faf91536587034; expires=Tue, 10-Sep-19
-        13:43:54 GMT; path=/; domain=.stellar.org; HttpOnly
-      Cache-Control:
-      - no-cache, no-store, max-age=0
-      Content-Disposition:
-      - inline
-      Vary:
-      - Origin
-      X-Ratelimit-Limit:
-      - '17200'
-      X-Ratelimit-Remaining:
-      - '17190'
-      X-Ratelimit-Reset:
-      - '3454'
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 4582538478a79997-LAX
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "_links": {
-            "transaction": {
-              "href": "https://horizon-testnet.stellar.org/transactions/2d9d893c26cbde9cf86d1cca05542881b4fbe84d4e1de611f951a67c6a386200"
-            }
-          },
-          "hash": "2d9d893c26cbde9cf86d1cca05542881b4fbe84d4e1de611f951a67c6a386200",
-          "ledger": 10982804,
-          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZACLCf4AAAAIAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAsbEeNGGlT07C/duCprnVzN1MEe3ugnaZegKNSXN+sToAAAAAO5rKAAAAAAAAAAABKATZaAAAAEAiEY6MoIP5g1l0I0PU24EORhVlBOQyvo8Kb+iC8Wg/O5vbKkyQxfIYH1ATgSmtbcjwp7aHKzG1XwPZoP3IqSYP",
-          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
-          "result_meta_xdr": "AAAAAQAAAAIAAAADAKeVlAAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAU9GsA4ACLCf4AAAAHAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAKeVlAAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAU9GsA4ACLCf4AAAAIAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAp5WUAAAAAAAAAACxsR40YaVPTsL924KmudXM3UwR7e6Cdpl6Ao1Jc36xOgAAAAA7msoAAKeVlAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAp5WUAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABT0awDgAIsJ/gAAAAgAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAp5WUAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABS40DbgAIsJ/gAAAAgAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
-        }
-    http_version: 
-  recorded_at: Mon, 10 Sep 2018 13:43:57 GMT
-- request:
-    method: get
-    uri: https://horizon-testnet.stellar.org/accounts/GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.15.2
-      Accept:
-      - application/hal+json,application/problem+json,application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 10 Sep 2018 13:43:58 GMT
-      Content-Type:
-      - application/hal+json; charset=utf-8
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - __cfduid=da825e94f9d1b3b3a4f22852acf31dade1536587038; expires=Tue, 10-Sep-19
-        13:43:58 GMT; path=/; domain=.stellar.org; HttpOnly
-      Cache-Control:
-      - no-cache, no-store, max-age=0
-      Content-Disposition:
-      - inline
-      Vary:
-      - Origin
-      X-Ratelimit-Limit:
-      - '17200'
-      X-Ratelimit-Remaining:
-      - '17188'
-      X-Ratelimit-Reset:
-      - '3453'
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 4582539c6a4422b2-LAX
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "_links": {
-            "self": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX"
-            },
-            "transactions": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX/transactions{?cursor,limit,order}",
-              "templated": true
-            },
-            "operations": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX/operations{?cursor,limit,order}",
-              "templated": true
-            },
-            "payments": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX/payments{?cursor,limit,order}",
-              "templated": true
-            },
-            "effects": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX/effects{?cursor,limit,order}",
-              "templated": true
-            },
-            "offers": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX/offers{?cursor,limit,order}",
-              "templated": true
-            },
-            "trades": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX/trades{?cursor,limit,order}",
-              "templated": true
-            },
-            "data": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX/data/{key}",
-              "templated": true
-            }
-          },
-          "id": "GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX",
-          "paging_token": "",
-          "account_id": "GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX",
-          "sequence": "47170783998377984",
-          "subentry_count": 0,
-          "thresholds": {
-            "low_threshold": 0,
-            "med_threshold": 0,
-            "high_threshold": 0
-          },
-          "flags": {
-            "auth_required": false,
-            "auth_revocable": false
-          },
-          "balances": [
-            {
-              "balance": "100.0000000",
-              "buying_liabilities": "0.0000000",
-              "selling_liabilities": "0.0000000",
-              "asset_type": "native"
-            }
-          ],
-          "signers": [
-            {
-              "public_key": "GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX",
-              "weight": 1,
-              "key": "GCY3CHRUMGSU6TWC7XNYFJVZ2XGN2TAR5XXIE5UZPIBI2SLTP2YTVBLX",
-              "type": "ed25519_public_key"
-            }
-          ],
-          "data": {}
-        }
-    http_version: 
-  recorded_at: Mon, 10 Sep 2018 13:43:58 GMT
-- request:
-    method: post
-    uri: https://horizon-testnet.stellar.org/transactions
-    body:
-      encoding: UTF-8
-      string: tx=AAAAALGxHjRhpU9Owv3bgqa51czdTBHt7oJ2mXoCjUlzfrE6AAAAZACnlZQAAAABAAAAAAAAAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa%2FVa29KATZaAAAAAEAAAAAUmq2RtQGuBwYKjA%2FEtUHJrO2kOyQohEGjviLLi%2FqQCkAAAAAAAAAAFloLwAAAAAAAAAAAnN%2BsToAAABAiD3rwskI7ViJTDt2sD1deW6owPk3bOX9aR97h%2BY7tW53DH8tmO3nhUT17ZoIDPE1xtrJHw2l6d%2B430iWTga9DigE2WgAAABAk3kfcpy%2FtC20wNEKSIx03TNVQoqJkMmsAcl5ji%2BJmKxenVoRAaYFzVNRcNnvdZF1JMxpxyQRgAAhhF3BSqVBCA%3D%3D
-    headers:
-      User-Agent:
-      - Faraday v0.15.2
-      Accept:
-      - application/hal+json,application/problem+json,application/json
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 10 Sep 2018 13:44:02 GMT
-      Content-Type:
-      - application/hal+json; charset=utf-8
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - __cfduid=dd3050cee91a238cb7c711e152a7e85931536587039; expires=Tue, 10-Sep-19
-        13:43:59 GMT; path=/; domain=.stellar.org; HttpOnly
-      Cache-Control:
-      - no-cache, no-store, max-age=0
-      Content-Disposition:
-      - inline
-      Vary:
-      - Origin
-      X-Ratelimit-Limit:
-      - '17200'
-      X-Ratelimit-Remaining:
-      - '17189'
-      X-Ratelimit-Reset:
-      - '3449'
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 458253a4fd1f997f-LAX
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "_links": {
-            "transaction": {
-              "href": "https://horizon-testnet.stellar.org/transactions/6f6e33764ac7a15bd96ca16c0160d62a741e0df6bf689f5a56225d1f7defdc68"
-            }
-          },
-          "hash": "6f6e33764ac7a15bd96ca16c0160d62a741e0df6bf689f5a56225d1f7defdc68",
-          "ledger": 10982805,
-          "envelope_xdr": "AAAAALGxHjRhpU9Owv3bgqa51czdTBHt7oJ2mXoCjUlzfrE6AAAAZACnlZQAAAABAAAAAAAAAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAAEAAAAAUmq2RtQGuBwYKjA/EtUHJrO2kOyQohEGjviLLi/qQCkAAAAAAAAAAFloLwAAAAAAAAAAAnN+sToAAABAiD3rwskI7ViJTDt2sD1deW6owPk3bOX9aR97h+Y7tW53DH8tmO3nhUT17ZoIDPE1xtrJHw2l6d+430iWTga9DigE2WgAAABAk3kfcpy/tC20wNEKSIx03TNVQoqJkMmsAcl5ji+JmKxenVoRAaYFzVNRcNnvdZF1JMxpxyQRgAAhhF3BSqVBCA==",
-          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
-          "result_meta_xdr": "AAAAAQAAAAIAAAADAKeVlQAAAAAAAAAAsbEeNGGlT07C/duCprnVzN1MEe3ugnaZegKNSXN+sToAAAAAO5rJnACnlZQAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAKeVlQAAAAAAAAAAsbEeNGGlT07C/duCprnVzN1MEe3ugnaZegKNSXN+sToAAAAAO5rJnACnlZQAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMAp5WTAAAAAAAAAABSarZG1Aa4HBgqMD8S1Qcms7aQ7JCiEQaO+IsuL+pAKQAAAAA7msoAAKeVkwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAp5WVAAAAAAAAAABSarZG1Aa4HBgqMD8S1Qcms7aQ7JCiEQaO+IsuL+pAKQAAAACVAvkAAKeVkwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAp5WUAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABS40DbgAIsJ/gAAAAgAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAp5WVAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABRfaAfgAIsJ/gAAAAgAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
-        }
-    http_version: 
-  recorded_at: Mon, 10 Sep 2018 13:44:02 GMT
-- request:
-    method: get
-    uri: https://horizon-testnet.stellar.org/accounts/GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.15.2
-      Accept:
-      - application/hal+json,application/problem+json,application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 10 Sep 2018 13:44:03 GMT
-      Content-Type:
-      - application/hal+json; charset=utf-8
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - __cfduid=dd2a3e2cb192ec9ec9a49ddb036a6a86c1536587042; expires=Tue, 10-Sep-19
-        13:44:02 GMT; path=/; domain=.stellar.org; HttpOnly
-      Cache-Control:
-      - no-cache, no-store, max-age=0
-      Content-Disposition:
-      - inline
-      Vary:
-      - Origin
-      X-Ratelimit-Limit:
-      - '17200'
-      X-Ratelimit-Remaining:
-      - '17187'
-      X-Ratelimit-Reset:
-      - '3448'
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 458253ba5e5f997f-LAX
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "_links": {
-            "self": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5"
-            },
-            "transactions": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5/transactions{?cursor,limit,order}",
-              "templated": true
-            },
-            "operations": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5/operations{?cursor,limit,order}",
-              "templated": true
-            },
-            "payments": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5/payments{?cursor,limit,order}",
-              "templated": true
-            },
-            "effects": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5/effects{?cursor,limit,order}",
-              "templated": true
-            },
-            "offers": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5/offers{?cursor,limit,order}",
-              "templated": true
-            },
-            "trades": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5/trades{?cursor,limit,order}",
-              "templated": true
-            },
-            "data": {
-              "href": "https://horizon-testnet.stellar.org/accounts/GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5/data/{key}",
-              "templated": true
-            }
-          },
-          "id": "GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5",
-          "paging_token": "",
-          "account_id": "GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5",
-          "sequence": "47170779703410688",
-          "subentry_count": 0,
-          "thresholds": {
-            "low_threshold": 0,
-            "med_threshold": 0,
-            "high_threshold": 0
-          },
-          "flags": {
-            "auth_required": false,
-            "auth_revocable": false
-          },
-          "balances": [
-            {
-              "balance": "250.0000000",
-              "buying_liabilities": "0.0000000",
-              "selling_liabilities": "0.0000000",
-              "asset_type": "native"
-            }
-          ],
-          "signers": [
-            {
-              "public_key": "GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5",
-              "weight": 1,
-              "key": "GBJGVNSG2QDLQHAYFIYD6EWVA4TLHNUQ5SIKEEIGR34IWLRP5JACTZI5",
-              "type": "ed25519_public_key"
-            }
-          ],
-          "data": {}
-        }
-    http_version: 
-  recorded_at: Mon, 10 Sep 2018 13:44:03 GMT
+  recorded_at: Wed, 12 Sep 2018 16:02:59 GMT
 recorded_with: VCR 3.0.3

--- a/spec/lib/stellar/client_spec.rb
+++ b/spec/lib/stellar/client_spec.rb
@@ -148,7 +148,7 @@ describe Stellar::Client do
         client.create_account(
           funder: source,
           account: channel_account,
-          starting_balance: 100,
+          starting_balance: 1000,
         )
 
         amount = Stellar::Amount.new(150)
@@ -159,8 +159,9 @@ describe Stellar::Client do
           amount: amount,
           source_account: source
         )
+
         tx_hash = tx._attributes
-                    .instance_variable_get(:@collection)[:hash]
+                    .instance_variable_get(:@collection)["hash"]
 
         operation = client.horizon
                           .transaction(hash: tx_hash)
@@ -172,8 +173,7 @@ describe Stellar::Client do
                                           ._attributes
                                           .instance_variable_get(:@collection)["from"]
 
-        source_account_info = client.account_info(source)
-        expect(operation_from_address).to eq source_account_info["id"]
+        expect(operation_from_address).to eq source.address
 
         destination_info = client.account_info(destination)
         balances = destination_info.balances

--- a/spec/lib/stellar/client_spec.rb
+++ b/spec/lib/stellar/client_spec.rb
@@ -153,12 +153,27 @@ describe Stellar::Client do
 
         amount = Stellar::Amount.new(150)
 
-        client.send_payment(
+        tx = client.send_payment(
           from: channel_account,
           to: destination,
           amount: amount,
           source_account: source
         )
+        tx_hash = tx._attributes
+                    .instance_variable_get(:@collection)[:hash]
+
+        operation = client.horizon
+                          .transaction(hash: tx_hash)
+                          .operations
+                          ._get
+
+        operation_from_address = operation.records
+                                          .first
+                                          ._attributes
+                                          .instance_variable_get(:@collection)["from"]
+
+        source_account_info = client.account_info(source)
+        expect(operation_from_address).to eq source_account_info["id"]
 
         destination_info = client.account_info(destination)
         balances = destination_info.balances


### PR DESCRIPTION
This allows Stellar::Client#send_payment to accept a
source account option.
Generate a test case for sending native assets to an
account through a channel account.