### PR TITLE
Set Stellar.default_network in Client factory methods

### DIFF
--- a/lib/stellar/client.rb
+++ b/lib/stellar/client.rb
@@ -17,24 +17,24 @@ module Stellar
     FRIENDBOT_URL = 'https://friendbot.stellar.org'.freeze
 
     def self.default(options={})
-      new {
+      new options.merge(
         network: Stellar::Networks::PUBLIC,
         horizon: HORIZON_MAINNET_URL
-      }.merge(options)
+      )
     end
 
     def self.default_testnet(options={})
-      new {
+      new options.merge(
         network: Stellar::Networks::TESTNET,
         horizon:   HORIZON_TESTNET_URL,
         friendbot: HORIZON_TESTNET_URL,
-      }.merge(options)
+      )
     end
 
     def self.localhost(options={})
-      new {
+      new options.merge(
         horizon: HORIZON_LOCALHOST_URL
-      }.merge(options)
+      )
     end
 
     attr_reader :horizon

--- a/lib/stellar/client.rb
+++ b/lib/stellar/client.rb
@@ -17,22 +17,24 @@ module Stellar
     FRIENDBOT_URL = 'https://friendbot.stellar.org'.freeze
 
     def self.default(options={})
-      new options.merge(
+      new {
+        network: Stellar::Networks::PUBLIC,
         horizon: HORIZON_MAINNET_URL
-      )
+      }.merge(options)
     end
 
     def self.default_testnet(options={})
-      new options.merge(
+      new {
+        network: Stellar::Networks::TESTNET,
         horizon:   HORIZON_TESTNET_URL,
         friendbot: HORIZON_TESTNET_URL,
-      )
+      }.merge(options)
     end
 
     def self.localhost(options={})
-      new options.merge(
+      new {
         horizon: HORIZON_LOCALHOST_URL
-      )
+      }.merge(options)
     end
 
     attr_reader :horizon
@@ -54,6 +56,9 @@ module Stellar
           "X-Client-Version" => VERSION,
         }
       end
+      # TODO: add a network_passphrase parameter per client call like other SDK's 
+      # instead of setting a default for the module.
+      Stellar.default_network = options[:network]
     end
 
     Contract Stellar::Account => Any


### PR DESCRIPTION
resolves #22 

Sets `Stellar.default_network` in `Stellar::Client.default` and `Stellar::Client.default_testnet` accordingly. 

At some point in the future the Ruby SDK should mirror the other SDKs by expecting a `network_passphrase` parameter for client methods.