### PR TITLE
Raise useful Horizon errors

### DIFF
--- a/sdk/lib/stellar-sdk.rb
+++ b/sdk/lib/stellar-sdk.rb
@@ -6,6 +6,7 @@ module Stellar
   autoload :Amount
   autoload :Client
   autoload :SEP10
+  autoload :HorizonError
 
   module Horizon
     extend ActiveSupport::Autoload

--- a/sdk/lib/stellar/client.rb
+++ b/sdk/lib/stellar/client.rb
@@ -200,6 +200,9 @@ module Stellar
         check_memo_required(tx_envelope)
       end
       @horizon.transactions._post(tx: tx_envelope.to_xdr(:base64))
+
+    rescue Faraday::BadRequestError => ex
+      raise HorizonError.make(ex.response[:body])
     end
 
     # Required by SEP-0029

--- a/sdk/lib/stellar/horizon_error.rb
+++ b/sdk/lib/stellar/horizon_error.rb
@@ -1,0 +1,53 @@
+module Stellar
+  class HorizonError < StandardError
+    attr_reader :original_response, :extras
+
+    def self.make(original_response)
+      klass = class_for(original_response["title"])
+      klass.new(original_response)
+    end
+
+    # Uses specialized class if it is defined
+    def self.class_for(title)
+      const_get title.delete(" ").to_sym
+    rescue NameError
+      self
+    end
+
+    def initialize(original_response)
+      message = make_message(
+        detail: original_response["detail"],
+        title: original_response["title"]
+      )
+
+      # Superclass StandardError has different argument signature
+      super(message)
+
+      @original_response = original_response
+      @extras = original_response["extras"]
+    end
+
+    private
+
+    def make_message(detail:, title:)
+      # Include title only on generic class
+      # Condition passes only for child classes
+      if self.class != HorizonError
+        title = nil
+      end
+
+      [title, detail].compact.join(": ")
+    end
+
+    class TransactionFailed < self
+      def make_message(detail:)
+        detail.sub!(
+          "The `extras.result_codes` field on this response contains further details.",
+          "extras.result_codes contained: `#{hash.dig("extras", "result_codes")}`"
+        )
+      end
+    end
+
+    class TransactionMalformed < self; end
+  end
+end


### PR DESCRIPTION
I caught this on the side while working on something else, my apologies for the missing tests; I didn't have time to figure out how to set up the accounts correctly just yet.

1. I ran into Horizon rejecting the XDR envelopes made from a regular `send_payment` request. The exception raised was as such:

```
     Faraday::BadRequestError:
       the server responded with status 400
     # ./lib/account.rb:20:in `send_payment'
```

Which is not exactly helpful. Which is why I'm humbly proposing to wrap those into exceptions ourselves to raise some more useful information. It would now become:

```
     Stellar::HorizonError::TransactionMalformed:
       Horizon could not decode the transaction envelope in this request. A transaction should be an XDR TransactionEnvelope struct encoded using base64.  The envelope read from this request is echoed in the `extras.envelope_xdr` field of this response for your convenience.

# or

     Stellar::HorizonError::TransactionFailed:
       The transaction failed when submitted to the stellar network. extras.result_codes contained: `{"transaction"=>"tx_failed", "operations"=>["op_no_destination"]}`  Descriptions of each code can be found at: https://www.stellar.org/developers/guides/concepts/list-of-operations.html
```

It also makes available `.extras` on the exception. (On further thought, `original_hash` should probably be named `original_response`).

[...]

After being done, I saw there were already `Stellar::AccountRequiresMemoError` and `Stellar::Horizon::Problem`, we could probably clean this up together if you'd like.


Cheers!