### PR TITLE
Client#submit_tx.: Fix Base64 encoding

### DIFF
--- a/sdk/lib/stellar/client.rb
+++ b/sdk/lib/stellar/client.rb
@@ -199,7 +199,7 @@ module Stellar
       unless options[:skip_memo_required_check]
         check_memo_required(tx_envelope)
       end
-      @horizon.transactions._post(tx: Base64.encode64(tx_envelope.to_xdr))
+      @horizon.transactions._post(tx: tx_envelope.to_xdr(:base64))
     end
 
     # Required by SEP-0029


### PR DESCRIPTION
Without strict, produces newline characters which Horizon will reject

---

(Split from #95:)

And so I was getting some TransactionMalformed errors. Looks like this is because Base64.encode64 by default inserts some newlines, which Horizon doesn't like.

The tests probably didn't catch this because of some combination of using VCR and upgrades on our side.