### PR TITLE
Post Protocol 13 release

### DIFF
--- a/base/lib/stellar/transaction.rb
+++ b/base/lib/stellar/transaction.rb
@@ -170,6 +170,24 @@ module Stellar
       end
     end
 
+    def to_v0
+      ed25519 = if source_account.switch == Stellar::CryptoKeyType.key_type_ed25519
+        source_account.ed25519!
+      else
+        source_account.med25519!.ed25519
+      end
+
+      TransactionV0.new(
+        source_account_ed25519: ed25519,
+        seq_num: seq_num,
+        operations: operations,
+        fee: fee,
+        memo: memo,
+        time_bounds: time_bounds,
+        ext: ext
+      )
+    end
+
     def signature_base
       tagged_tx = Stellar::TransactionSignaturePayload::TaggedTransaction.new(:envelope_type_tx, self)
       Stellar::TransactionSignaturePayload.new(

--- a/base/lib/stellar/transaction_v0.rb
+++ b/base/lib/stellar/transaction_v0.rb
@@ -2,6 +2,18 @@ module Stellar
   class TransactionV0
     include Stellar::Concerns::Transaction
 
+    def to_v1
+      Transaction.new(
+        source_account: Stellar::MuxedAccount.new(:key_type_ed25519, source_account),
+        seq_num: seq_num,
+        operations: operations,
+        fee: fee,
+        memo: memo,
+        time_bounds: time_bounds,
+        ext: ext
+      )
+    end
+
     def to_envelope(*key_pairs)
       signatures = (key_pairs || []).map(&method(:sign_decorated))
 

--- a/base/spec/spec_helper.rb
+++ b/base/spec/spec_helper.rb
@@ -13,4 +13,5 @@ Dir["#{SPEC_ROOT}/support/**/*.rb"].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.filter_run_when_matching focus: true
+  config.run_all_when_everything_filtered = true
 end

--- a/sdk/lib/stellar/sep10.rb
+++ b/sdk/lib/stellar/sep10.rb
@@ -75,7 +75,7 @@ module Stellar
         )
       end
 
-      if transaction.source_account != server.raw_public_key
+      if transaction.source_account != server.muxed_account
         raise InvalidSep10ChallengeError.new(
           "The transaction source account is not equal to the server's account"
         )

--- a/sdk/spec/lib/stellar/client_spec.rb
+++ b/sdk/spec/lib/stellar/client_spec.rb
@@ -668,8 +668,7 @@ describe Stellar::Client do
 
         inner_tx = Stellar::TransactionBuilder.new(
           source_account: inner_tx_source,
-          sequence_number: inner_tx_seq_num,
-          v1: true
+          sequence_number: inner_tx_seq_num
         ).add_operation(
           Stellar::Operation.payment(
             destination: memo_required_kp,

--- a/sdk/spec/lib/stellar/sep10_spec.rb
+++ b/sdk/spec/lib/stellar/sep10_spec.rb
@@ -18,7 +18,7 @@ describe Stellar::SEP10 do
     it "generates a valid SEP10 challenge" do
       expect(transaction.seq_num).to eql(0)
       expect(transaction.operations.size).to eql(1)
-      expect(transaction.source_account).to eql(server.raw_public_key)
+      expect(transaction.source_account).to eql(server.muxed_account)
 
       time_bounds = transaction.time_bounds
       expect(time_bounds.max_time - time_bounds.min_time).to eql(600)


### PR DESCRIPTION
Resolves #98 

This PR implements next things:

1. `TransactionBuilder` generates V1 transaction envelopes instead of V0 transaction envelopes
1. SDK now allows you to fee bump a V0 transaction

**Note** We should merge it and publish a new version after protocol 13 is enabled on the pubnet