### PR TITLE
feat(protocol): support protocol 17

### DIFF
--- a/base/lib/stellar-base.rb
+++ b/base/lib/stellar-base.rb
@@ -35,6 +35,7 @@ require_relative "./stellar/path_payment_strict_receive_result"
 require_relative "./stellar/price"
 require_relative "./stellar/signer_key"
 require_relative "./stellar/thresholds"
+require_relative "./stellar/trust_line_flags"
 
 require_relative "./stellar/concerns/transaction"
 require_relative "./stellar/fee_bump_transaction"

--- a/base/lib/stellar/compat.rb
+++ b/base/lib/stellar/compat.rb
@@ -4,5 +4,6 @@ class << Stellar::Operation
 
   deprecate deprecator: Stellar::Deprecation,
             manage_offer: :manage_sell_offer,
-            create_passive_offer: :create_passive_sell_offer
+            create_passive_offer: :create_passive_sell_offer,
+            allow_trust: :set_trust_line_flags
 end

--- a/base/lib/stellar/concerns/transaction.rb
+++ b/base/lib/stellar/concerns/transaction.rb
@@ -19,7 +19,7 @@ module Stellar::Concerns
     end
 
     def merge(other)
-      cloned = Marshal.load Marshal.dump(self)
+      cloned = from_xdr(to_xdr)
       cloned.operations += other.to_operations
       cloned
     end
@@ -32,7 +32,9 @@ module Stellar::Concerns
     #
     # @return [Array<Operation>] the operations
     def to_operations
-      cloned = Marshal.load Marshal.dump(operations)
+      codec = XDR::VarArray[Stellar::Operation]
+      ops = respond_to?(:operations) ? operations : inner_tx.value.tx.operations
+      cloned = codec.from_xdr(codec.to_xdr(ops))
       cloned.each do |op|
         op.source_account ||= source_account
       end

--- a/base/lib/stellar/dsl.rb
+++ b/base/lib/stellar/dsl.rb
@@ -27,6 +27,9 @@ module Stellar
       )
     end
 
+    # @param [Asset, String, nil] subject
+    # @return [Stellar::Asset] instance of the Stellar::Asset
+    # @raise [TypeError] if subject cannot be converted to Stellar::Asset
     def Asset(subject = nil)
       case subject
       when Asset
@@ -45,6 +48,7 @@ module Stellar
     # Generates Stellar::Keypair from subject, use Stellar::Client.to_keypair as shortcut.
     # @param subject [String|Stellar::Account|Stellar::PublicKey|Stellar::SignerKey|Stellar::Keypair] subject.
     # @return [Stellar::Keypair] Stellar::Keypair instance.
+    # @raise [TypeError] if subject cannot be converted to Stellar::KeyPair
     def KeyPair(subject = nil)
       case subject
       when ->(subj) { subj.respond_to?(:to_keypair) }

--- a/base/lib/stellar/trust_line_flags.rb
+++ b/base/lib/stellar/trust_line_flags.rb
@@ -1,0 +1,53 @@
+module Stellar
+  class TrustLineFlags
+    # Converts an array of Stellar::TrustLineFlags members into
+    # an integers suitable for use in in a SetTrustLineFlagsOp.
+    #
+    # @param flags [Array<Stellar::TrustLineFlags>] the flags to combine
+    #
+    # @return [Fixnum] the combined result
+    def self.make_mask(flags)
+      normalize(flags).map(&:value).inject(&:|) || 0
+    end
+
+    # Converts an integer used in SetTrustLineFlagsOp on the set/clear flag options
+    # into an array of Stellar::TrustLineFlags members
+    #
+    #  @param combined [Fixnum]
+    #  @return [Array<Stellar::AccountFlags>]
+    def self.parse_mask(combined)
+      members.values.select { |m| (m.value & combined) != 0 }
+    end
+
+    # Converts each element of the input array to Stellar::TrustLineFlags instance.
+    #
+    # @param [Array<Stellar::TrustLineFlags,Symbol,#to_s>] input
+    # @return [Array<Stellar::TrustLineFlags>]
+    # @raise [TypeError] if any element of the input cannot be converted
+    def self.normalize(input)
+      input.map do |val|
+        case val
+        when Stellar::TrustLineFlags
+          val
+        when ->(_) { members.key?(val.to_s) }
+          from_name(val.to_s)
+        when ->(_) { members.key?("#{val}_flag") }
+          from_name("#{val}_flag")
+        else
+          raise TypeError, "unknown trustline flag: #{val}"
+        end
+      end
+    end
+
+    def self.set_clear_masks(flags)
+      set_flags = []
+      clear_flags = []
+
+      Hash(flags).each do |flag, value|
+        value.present? ? set_flags.push(flag) : clear_flags.push(flag)
+      end
+
+      {set_flags: make_mask(set_flags), clear_flags: make_mask(clear_flags)}
+    end
+  end
+end


### PR DESCRIPTION
Resolves #134

# New operations

- [x] `clawback`
- [x] `clawback_claimable_balance`
- [x] `set_trust_line_flags`

# Deprecations

- [x] Operation `allow_trust` is deprecated in favor of `set_trust_line_flags`

## Note
Protocol changes regarding effects are not relevant for Ruby SDK, since we don't use them anywhere (yet)