### PR TITLE
chore: use `main` branch as default

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,0 +1,14 @@
+{
+  "bootstrap-sha": "571cb1b71ac32484321041b64507edcd926fc4cb",
+  "release-type": "ruby",
+  "bump-minor-pre-major": true,
+  "packages": {
+    "base": {
+      "package-name": "stellar-base"
+    },
+
+    "sdk": {
+      "package-name": "stellar-sdk"
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
     paths-ignore: [ '**/README.md', '**/CHANGELOG.md' ]
   push:
-    branches: [ main, master ]
+    branches: [ main ]
     paths-ignore: [ '**/README.md', '**/CHANGELOG.md' ]
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,9 +1,9 @@
 name: Security Checks
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
   schedule:
   - cron: '43 0 * * 4'
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ ask contributors to follow so that we can merge your changes quickly.
 ## Making Changes
 
 * Create a topic branch from where you want to base your work.
-  * This is usually the master branch.
-  * Please avoid working directly on the `master` branch.
+  * This is usually the `main` branch.
+  * Please avoid working directly on the `main` branch.
 * Make sure you have added the necessary tests for your changes, and make sure all tests pass.
 
 ## Submitting Changes
@@ -35,14 +35,12 @@ business days. We may suggest some changes or improvements or alternatives.
 # Additional Resources
 
 * [Bug tracker (Github)](https://github.com/astroband/ruby-stellar-sdk/issues)
-* <a href="https://docs.google.com/forms/d/1g7EF6PERciwn7zfmfke5Sir2n10yddGGSXyZsq98tVY/viewform?usp=send_form">Contributor License Agreement</a>
-* #stellar-dev IRC channel on freenode.org and Slack chat on stellar-public.slack.com
 
 
 This document is inspired by:
 
 https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md
 
-https://github.com/thoughtbot/factory_girl_rails/blob/master/CONTRIBUTING.md
+https://github.com/thoughtbot/factory_bot_rails/blob/master/CONTRIBUTING.md
 
 https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Community maintained Ruby SDK for Stellar
 
-This repo contains both `stellar-sdk` and `stellar-base` gems. You can check corresponding READMEs: [SDK](https://github.com/astroband/ruby-stellar-sdk/blob/master/sdk/README.md) and [base](https://github.com/astroband/ruby-stellar-sdk/blob/master/base/README.md)
+This repo contains both `stellar-sdk` and `stellar-base` gems. You can check corresponding READMEs: [SDK](https://github.com/astroband/ruby-stellar-sdk/blob/main/sdk/README.md) and [base](https://github.com/astroband/ruby-stellar-sdk/blob/main/base/README.md)
 
 
 ## License

--- a/base/CHANGELOG.md
+++ b/base/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
-## [Unreleased](https://github.com/astroband/ruby-stellar-sdk/compare/v0.26.0...master)
-
 ## [0.26.0](https://github.com/astroband/ruby-stellar-sdk/compare/v0.25.0...v0.26.0) - 2021-02-05
 - No changes
 

--- a/base/stellar-base.gemspec
+++ b/base/stellar-base.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
     "bug_tracker_uri" => "#{spec.homepage}/issues",
     "changelog_uri" => "#{spec.homepage}/blob/v#{spec.version}/base/CHANGELOG.md",
     "documentation_uri" => "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/",
-    "homepage_uri" => "#{spec.homepage}/tree/master/base",
+    "homepage_uri" => "#{spec.homepage}/tree/main/base",
     "source_code_uri" => "#{spec.homepage}/tree/v#{spec.version}/base"
   }
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased](https://github.com/astroband/ruby-stellar-sdk/compare/v0.26.0...master)
-
 ## [0.26.0](https://github.com/astroband/ruby-stellar-sdk/compare/v0.25.0...v0.26.0) - 2021-02-05
 ### Changed
 - `Stellar::SEP10` is updated to comply with SEP10 v3.0.0 and v3.1.0

--- a/sdk/stellar-sdk.gemspec
+++ b/sdk/stellar-sdk.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
     "bug_tracker_uri" => "#{spec.homepage}/issues",
     "changelog_uri" => "#{spec.homepage}/blob/v#{spec.version}/sdk/CHANGELOG.md",
     "documentation_uri" => "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/",
-    "homepage_uri" => "#{spec.homepage}/tree/master/sdk",
+    "homepage_uri" => "#{spec.homepage}/tree/main/sdk",
     "source_code_uri" => "#{spec.homepage}/tree/v#{spec.version}/sdk"
   }
 


### PR DESCRIPTION
A few housekeeping tasks:

- [x] Update references to the `master` branch, to point to `main`
- [x] Add basic `release-please` manifests