### PR TITLE
chore(deps-dev): update addressable, break, faraday, rake, standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.4
     - name: Check markdown files for broken links
-      uses: justinbeckwith/linkinator-action@v1.5.4
+      uses: justinbeckwith/linkinator-action@v1.6.1
       with:
         paths: '*.md, base/**/*.md, sdk/**/*.md'
         verbosity: 'INFO'

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,8 @@ group :test do
 end
 
 group :lint do
-  gem "bundler-audit"
-  gem "standard", "1.1.1", require: false
+  gem "bundler-audit", require: false
+  gem "standard", require: false
   gem "yard-junk", require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,13 +29,13 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     awesome_print (1.9.2)
     backports (3.21.0)
     base32 (0.3.4)
-    break (0.21.0)
+    break (0.30.0)
     bundler-audit (0.8.0)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
@@ -51,19 +51,23 @@ GEM
       rake (>= 12.0.0, < 14.0.0)
     docile (1.3.5)
     excon (0.81.0)
-    faraday (1.4.2)
+    faraday (1.5.1)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0.1)
       faraday-net_http (~> 1.0)
       faraday-net_http_persistent (~> 1.1)
+      faraday-patron (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords (>= 0.0.4)
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
     faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.1.0)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
     faraday_hal_middleware (0.1.1)
       faraday_middleware (>= 0.9)
     faraday_middleware (1.0.0)
@@ -111,7 +115,7 @@ GEM
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.20.1)
-    parser (3.0.1.1)
+    parser (3.0.2.0)
       ast (~> 2.4.1)
     polyglot (0.3.5)
     pry (0.14.1)
@@ -126,7 +130,7 @@ GEM
       yard (~> 0.9.11)
     public_suffix (4.0.6)
     rainbow (3.0.0)
-    rake (13.0.3)
+    rake (13.0.6)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -150,18 +154,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    rubocop (1.14.0)
+    rubocop (1.18.3)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.5.0, < 2.0)
+      rubocop-ast (>= 1.7.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.5.0)
+    rubocop-ast (1.8.0)
       parser (>= 3.0.1.1)
-    rubocop-performance (1.11.2)
+    rubocop-performance (1.11.4)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
@@ -179,9 +183,9 @@ GEM
     slop (3.6.0)
     spoon (0.0.6)
       ffi
-    standard (1.1.1)
-      rubocop (= 1.14.0)
-      rubocop-performance (= 1.11.2)
+    standard (1.1.5)
+      rubocop (= 1.18.3)
+      rubocop-performance (= 1.11.4)
     thor (1.1.0)
     toml-rb (2.0.1)
       citrus (~> 3.0, > 3.0)
@@ -231,7 +235,7 @@ DEPENDENCIES
   rspec
   rspec-its
   simplecov
-  standard (= 1.1.1)
+  standard
   stellar-base!
   stellar-sdk!
   vcr
@@ -241,4 +245,4 @@ DEPENDENCIES
   yard-junk
 
 BUNDLED WITH
-   2.2.16
+   2.2.22

--- a/base/lib/stellar/compat.rb
+++ b/base/lib/stellar/compat.rb
@@ -2,8 +2,10 @@ class << Stellar::Operation
   alias_method :manage_offer, :manage_sell_offer
   alias_method :create_passive_offer, :create_passive_sell_offer
 
-  deprecate deprecator: Stellar::Deprecation,
-            manage_offer: :manage_sell_offer,
-            create_passive_offer: :create_passive_sell_offer,
-            allow_trust: :set_trust_line_flags
+  deprecate(
+    deprecator: Stellar::Deprecation,
+    manage_offer: :manage_sell_offer,
+    create_passive_offer: :create_passive_sell_offer,
+    allow_trust: :set_trust_line_flags
+  )
 end

--- a/sdk/spec/lib/stellar/client_spec.rb
+++ b/sdk/spec/lib/stellar/client_spec.rb
@@ -347,8 +347,7 @@ RSpec.describe Stellar::Client do
       end
 
       it "accepts a cursor to return less data", vcr: {record: :once, match_requests_on: [:method]} do
-        response = client.transactions(account: account,
-                                       cursor: cursor)
+        response = client.transactions(account: account, cursor: cursor)
         expect(response).to be_a(Stellar::TransactionPage)
       end
     end


### PR DESCRIPTION
- [addressable](https://github.com/sporkmonger/addressable) 2.7.0 → 2.8.0 <details><summary>Changelog</summary><p><em>Sourced from <a href="https://github.com/sporkmonger/addressable/blob/main/CHANGELOG.md">addressable's changelog</a>.</em></p><blockquote><h1>Addressable 2.8.0</h1><ul><li>fixes ReDoS vulnerability in Addressable::Template#match</li><li>no longer replaces <code>+</code> with spaces in queries for non-http(s) schemes</li><li>fixed encoding ipv6 literals</li><li>the <code>:compacted</code> flag for <code>normalized_query</code> now dedupes parameters</li><li>fix broken <code>escape_component</code> alias</li><li>dropping support for Ruby 2.0 and 2.1</li><li>adding Ruby 3.0 compatibility for development tasks</li><li>drop support for <code>rack-mount</code> and remove Addressable::Template#generate</li><li>performance improvements</li><li>switch CI/CD to GitHub Actions</li></ul></blockquote></details>

- [break](https://github.com/gsamokovarov/break) 0.21.0 → 0.30.0<details><summary>Release notes</summary><p><em>Sourced from <a href="https://github.com/gsamokovarov/break/releases">break's releases</a>.</em></p><blockquote><h2>0.30.0</h2><h3>Added</h3><ul><li>Officially Ruby 3.0 support. (<a href="https://github.com/gsamokovarov"><code>@​gsamokovarov</code></a>)</li></ul><h3>Fixed</h3><ul><li>Fix broken <code>next</code> command for Ruby 2.7+. (<a href="https://github.com/gsamokovarov"><code>@​gsamokovarov</code></a>)</li><li>Fix circular require for <code>pry</code> integrations. (<a href="https://github.com/gsamokovarov"><code>@​gsamokovarov</code></a>)</li></ul></blockquote></details><details><summary>Changelog</summary><p><em>Sourced from <a href="https://github.com/gsamokovarov/break/blob/master/CHANGELOG.md">break's changelog</a>.</em></p><blockquote><h2>0.30.0 (2021-06-20)</h2><h3>Added</h3><ul><li>Officially Ruby 3.0 support. ([<a href="https://github.com/gsamokovarov"><code>@​gsamokovarov</code></a>][])</li></ul><h3>Fixed</h3><ul><li>Fix broken <code>next</code> command for Ruby 2.7+. ([<a href="https://github.com/gsamokovarov"><code>@​gsamokovarov</code></a>][])</li><li>Fix circular require for <code>pry</code> integrations. ([<a href="https://github.com/gsamokovarov"><code>@​gsamokovarov</code></a>][])</li></ul></blockquote></details>

- [faraday](https://github.com/lostisland/faraday) 1.4.2 → 1.5.1 <details><summary>Release notes</summary><p><em>Sourced from <a href="https://github.com/lostisland/faraday/releases">faraday's releases</a>.</em></p><blockquote><h2>v1.5.1</h2><h2>Fixes</h2><ul><li>Fix JRuby incompatibility after moving out EM adapters (<a href="https://github-redirect.dependabot.com/lostisland/faraday/issues/1294">#1294</a>, <a href="https://github.com/ahorek"><code>@​ahorek</code></a>)</li></ul><h2>Documentation</h2><ul><li>Update YARD to follow RackBuilder (<a href="https://github-redirect.dependabot.com/lostisland/faraday/issues/1292">#1292</a>, <a href="https://github.com/kachick"><code>@​kachick</code></a>)</li></ul><h2>v1.5.0</h2><h2>Misc</h2><ul><li>Use external httpclient adapter (<a href="https://github-redirect.dependabot.com/lostisland/faraday/issues/1289">#1289</a>, <a href="https://github.com/iMacTia"><code>@​iMacTia</code></a>)</li><li>Use external patron adapter (<a href="https://github-redirect.dependabot.com/lostisland/faraday/issues/1290">#1290</a>, <a href="https://github.com/iMacTia"><code>@​iMacTia</code></a>)</li></ul><h2>v1.4.3</h2><h2>Fixes</h2><ul><li>silence warning (<a href="https://github-redirect.dependabot.com/lostisland/faraday/issues/1286">#1286</a>, <a href="https://github.com/gurgeous"><code>@​gurgeous</code></a>)</li><li>Always dup url_prefix in Connection#build_exclusive_url (<a href="https://github-redirect.dependabot.com/lostisland/faraday/issues/1288">#1288</a>, <a href="https://github.com/alexeyds"><code>@​alexeyds</code></a>)</li></ul></blockquote></details>

- [rake](https://github.com/ruby/rake) 13.0.3 → 13.0.6. <details><summary>Changelog</summary><p><em>Sourced from <a href="https://github.com/ruby/rake/blob/master/History.rdoc">rake's changelog</a>.</em></p><blockquote><p>=== 13.0.6</p><ul><li>Additional fix for <a href="https://github-redirect.dependabot.com/ruby/rake/issues/389">#389</a>
Pull request <a href="https://github-redirect.dependabot.com/ruby/rake/issues/390">#390</a> by hsbt</li></ul><p>=== 13.0.5</p><ul><li>Fixed the regression of <a href="https://github-redirect.dependabot.com/ruby/rake/issues/388">#388</a>
Pull request <a href="https://github-redirect.dependabot.com/ruby/rake/issues/389">#389</a> by hsbt</li></ul><p>=== 13.0.4</p><ul><li>Fix rake test loader swallowing useful error information.
Pull request <a href="https://github-redirect.dependabot.com/ruby/rake/issues/367">#367</a> by deivid-rodriguez</li><li>Add -C/--directory option the same as GNU make.
Pull request <a href="https://github-redirect.dependabot.com/ruby/rake/issues/376">#376</a> by nobu</li></ul></blockquote></details>

- [standard](https://github.com/testdouble/standard) 1.1.1 → 1.1.5 <details><summary>Release notes</summary><p><em>Sourced from <a href="https://github.com/testdouble/standard/releases">standard's releases</a>.</em></p><blockquote><h2>1.1.4</h2><ul><li>Update rubocop from 1.18.1 to <a href="https://github.com/rubocop-hq/rubocop/releases/tag/v1.18.2">1.18.2</a></li><li>Update rubocop-performance from 1.11.2 to <a href="https://github.com/rubocop-hq/rubocop-performance/releases/tag/v1.11.3">1.11.3</a></li></ul></blockquote></details><details><summary>Changelog</summary><p><em>Sourced from <a href="https://github.com/testdouble/standard/blob/main/CHANGELOG.md">standard's changelog</a>.</em></p><blockquote><h2>1.1.5</h2><ul><li>Update rubocop from 1.18.2 to <a href="https://github.com/rubocop-hq/rubocop/releases/tag/v1.18.3">1.18.3</a></li><li>Update rubocop-performance from 1.11.3 to <a href="https://github.com/rubocop-hq/rubocop-performance/releases/tag/v1.11.4">1.11.4</a></li><li>Disabled <code>Performance/DeletePrefix</code> because it was marked as unsafe.</li></ul><h2>1.1.4</h2><ul><li>Update rubocop from 1.18.1 to <a href="https://github.com/rubocop-hq/rubocop/releases/tag/v1.18.2">1.18.2</a></li><li>Update rubocop-performance from 1.11.2 to <a href="https://github.com/rubocop-hq/rubocop-performance/releases/tag/v1.11.3">1.11.3</a></li></ul><h2>1.1.3</h2><ul><li>Update rubocop from 1.17.0 to <a href="https://github.com/rubocop-hq/rubocop/releases/tag/v1.18.1">1.18.1</a></li></ul><h2>1.1.2</h2><ul><li>Update rubocop from 1.14.0 to <a href="https://github.com/rubocop-hq/rubocop/releases/tag/v1.17.0">1.17.0</a></li></ul></blockquote></details>

- [justinbeckwith/linkinator-action](https://github.com/justinbeckwith/linkinator-action) 1.5.4 → 1.6.1 <details><summary>Release notes</summary><p><em>Sourced from <a href="https://github.com/justinbeckwith/linkinator-action/releases">justinbeckwith/linkinator-action's releases</a>.</em></p><blockquote><h2>linkinator-action v1.6.1</h2><h3>Bug Fixes</h3><ul><li>show per-page rollup on failures (<a href="https://github-redirect.dependabot.com/JustinBeckwith/linkinator-action/issues/76">#76</a>) (<a href="https://www.github.com/JustinBeckwith/linkinator-action/commit/493ec2b63286faaaaeea8e0bf81a78ec96405893">493ec2b</a>)</li></ul><h2>linkinator-action v1.6.0</h2><h3>Features</h3><ul><li>add automatic branch url rewriting (<a href="https://github-redirect.dependabot.com/JustinBeckwith/linkinator-action/issues/75">#75</a>) (<a href="https://www.github.com/JustinBeckwith/linkinator-action/commit/446da1bed5a7babb38d0acc3d9da5f7f0c6b924c">446da1b</a>)</li><li>add url rewrites feature (<a href="https://github-redirect.dependabot.com/JustinBeckwith/linkinator-action/issues/73">#73</a>) (<a href="https://www.github.com/JustinBeckwith/linkinator-action/commit/2d475047904ed8dae142adabcbee292961d565a0">2d47504</a>)</li></ul></blockquote></details><details><summary>Changelog</summary><p><em>Sourced from <a href="https://github.com/JustinBeckwith/linkinator-action/blob/main/CHANGELOG.md">justinbeckwith/linkinator-action's changelog</a>.</em></p><blockquote><h3><a href="https://www.github.com/JustinBeckwith/linkinator-action/compare/v1.6.0...v1.6.1">1.6.1</a> (2021-07-12)</h3><h3>Bug Fixes</h3><ul><li>show per-page rollup on failures (<a href="https://github-redirect.dependabot.com/JustinBeckwith/linkinator-action/issues/76">#76</a>) (<a href="https://www.github.com/JustinBeckwith/linkinator-action/commit/493ec2b63286faaaaeea8e0bf81a78ec96405893">493ec2b</a>)</li></ul><h2><a href="https://www.github.com/JustinBeckwith/linkinator-action/compare/v1.5.4...v1.6.0">1.6.0</a> (2021-07-09)</h2><h3>Features</h3><ul><li>add automatic branch url rewriting (<a href="https://github-redirect.dependabot.com/JustinBeckwith/linkinator-action/issues/75">#75</a>) (<a href="https://www.github.com/JustinBeckwith/linkinator-action/commit/446da1bed5a7babb38d0acc3d9da5f7f0c6b924c">446da1b</a>)</li><li>add url rewrites feature (<a href="https://github-redirect.dependabot.com/JustinBeckwith/linkinator-action/issues/73">#73</a>) (<a href="https://www.github.com/JustinBeckwith/linkinator-action/commit/2d475047904ed8dae142adabcbee292961d565a0">2d47504</a>)</li></ul></blockquote></details>
