### PR TITLE
chore: extract Horizon client in separate gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 * `stellar-base` changelog: [base/CHANGELOG.md](https://github.com/astroband/ruby-stellar-sdk/blob/main/base/CHANGELOG.md)
 * `stellar-sdk` changelog: [sdk/CHANGELOG.md](https://github.com/astroband/ruby-stellar-sdk/blob/main/sdk/CHANGELOG.md)
+* `stellar-horizon` changelog: [sdk/CHANGELOG.md](https://github.com/astroband/ruby-stellar-sdk/blob/main/horizon/CHANGELOG.md)

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "stellar-base", path: "./base"
 gem "stellar-sdk", path: "./sdk"
+gem "stellar-horizon", path: "./horizon"
 # gem "xdr", github: "astroband/ruby-xdr"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,15 @@ PATH
       xdr (>= 3.0.2, < 4.0)
 
 PATH
+  remote: horizon
+  specs:
+    stellar-horizon (0.28.0)
+      excon (>= 0.71.0, < 1.0)
+      hyperclient (>= 0.7.0, < 2.0)
+      stellar-sdk (= 0.28.0)
+      toml-rb (>= 1.1.1, < 3.0)
+
+PATH
   remote: sdk
   specs:
     stellar-sdk (0.28.0)
@@ -237,6 +246,7 @@ DEPENDENCIES
   simplecov
   standard
   stellar-base!
+  stellar-horizon!
   stellar-sdk!
   vcr
   webmock

--- a/Rakefile
+++ b/Rakefile
@@ -12,10 +12,10 @@ task lint: %i[lint:all]
 
 task default: %i[test lint]
 
-rule(/^(base|sdk):.+$/) do |task|
+rule(/^(base|sdk|horizon):.+$/) do |task|
   gem_dir, task_name = task.name.split(":", 2)
   sh("cd #{gem_dir} && ../bin/rake #{task_name}")
 end
 
 desc "Build all gems"
-task build: %i[base:build sdk:build]
+task build: %i[base:build sdk:build horizon:build]

--- a/base/CHANGELOG.md
+++ b/base/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
+## [Unreleased]
+
 ## [0.28.0](https://www.github.com/astroband/ruby-stellar-sdk/compare/v0.27.0...v0.28.0) (2021-07-17)
 
 ### Features

--- a/base/lib/stellar/version.rb
+++ b/base/lib/stellar/version.rb
@@ -1,3 +1,3 @@
 module Stellar
-  VERSION = "0.28.0"
+  VERSION = "0.28.0".freeze
 end

--- a/horizon/.rspec
+++ b/horizon/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/horizon/CHANGELOG.md
+++ b/horizon/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this
+file. The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+As this project is pre 1.0, breaking changes may happen for minor version
+bumps.  A breaking change will get clearly notified in this log.
+
+## [Unreleased]
+### Added
+* Initial setup of the gem, copying all Horizon-related features from `sdk` gem

--- a/horizon/Rakefile
+++ b/horizon/Rakefile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/horizon/lib/stellar-horizon.rb
+++ b/horizon/lib/stellar-horizon.rb
@@ -1,0 +1,9 @@
+require "stellar-sdk"
+
+module Stellar
+  module Horizon
+    VERSION = ::Stellar::VERSION
+
+    autoload :Client, "#{__dir__}/stellar/horizon/client.rb"
+  end
+end

--- a/horizon/lib/stellar/horizon/client.rb
+++ b/horizon/lib/stellar/horizon/client.rb
@@ -1,0 +1,298 @@
+require "hyperclient"
+require "active_support/core_ext/object/blank"
+require "securerandom"
+
+module Stellar::Horizon
+  class AccountRequiresMemoError < StandardError
+    attr_reader :account_id, :operation_index
+
+    def initialize(message, account_id, operation_index)
+      super(message)
+      @account_id = account_id
+      @operation_index = operation_index
+    end
+  end
+
+  class Client
+    DEFAULT_FEE = 100
+
+    HORIZON_LOCALHOST_URL = "http://127.0.0.1:8000"
+    HORIZON_MAINNET_URL = "https://horizon.stellar.org"
+    HORIZON_TESTNET_URL = "https://horizon-testnet.stellar.org"
+    FRIENDBOT_URL = "https://friendbot.stellar.org".freeze
+
+    def self.default(options = {})
+      new options.merge(
+        horizon: HORIZON_MAINNET_URL
+      )
+    end
+
+    def self.default_testnet(options = {})
+      new options.merge(
+        horizon: HORIZON_TESTNET_URL,
+        friendbot: HORIZON_TESTNET_URL
+      )
+    end
+
+    def self.localhost(options = {})
+      new options.merge(
+        horizon: HORIZON_LOCALHOST_URL
+      )
+    end
+
+    attr_reader :horizon
+
+    # @option options [String] :horizon The Horizon server URL.
+    def initialize(options)
+      @options = options
+      @horizon = Hyperclient.new(options[:horizon]) { |client|
+        client.faraday_block = lambda do |conn|
+          conn.use Faraday::Response::RaiseError
+          conn.use FaradayMiddleware::FollowRedirects
+          conn.request :url_encoded
+          conn.response :hal_json, content_type: /\bjson$/
+          conn.adapter :excon
+        end
+        client.headers = {
+          "Accept" => "application/hal+json,application/problem+json,application/json",
+          "X-Client-Name" => "ruby-stellar-sdk",
+          "X-Client-Version" => Stellar::Horizon::VERSION
+        }
+      }
+    end
+
+    # @param [Stellar::Account|String] account_or_address
+    def account_info(account_or_address)
+      account_id = if account_or_address.is_a?(Stellar::Account)
+        account_or_address.address
+      else
+        account_or_address
+      end
+      @horizon.account(account_id: account_id)._get
+    end
+
+    # @option options [Stellar::Account] :account
+    # @option options [Stellar::Account] :destination
+    def account_merge(options = {})
+      account = options[:account]
+      destination = options[:destination]
+      sequence = options[:sequence] || (account_info(account).sequence.to_i + 1)
+
+      transaction = Stellar::TransactionBuilder.account_merge(
+        source_account: destination.keypair,
+        sequence_number: sequence,
+        destination: destination.keypair
+      )
+
+      envelope = transaction.to_envelope(account.keypair)
+      submit_transaction(tx_envelope: envelope)
+    end
+
+    def friendbot(account)
+      uri = URI.parse(FRIENDBOT_URL)
+      uri.query = "addr=#{account.address}"
+      Faraday.post(uri.to_s)
+    end
+
+    # @option options [Stellar::Account] :account
+    # @option options [Stellar::Account] :funder
+    # @option options [Integer] :starting_balance
+    def create_account(options = {})
+      funder = options[:funder]
+      sequence = options[:sequence] || (account_info(funder).sequence.to_i + 1)
+      # In the future, the fee should be grabbed from the network's last transactions,
+      # instead of using a hard-coded default value.
+      fee = options[:fee] || DEFAULT_FEE
+
+      payment = Stellar::TransactionBuilder.create_account(
+        source_account: funder.keypair,
+        sequence_number: sequence,
+        base_fee: fee,
+        destination: options[:account].keypair,
+        starting_balance: options[:starting_balance]
+      )
+      envelope = payment.to_envelope(funder.keypair)
+      submit_transaction(tx_envelope: envelope)
+    end
+
+    # @option options [Stellar::Account] :from The source account
+    # @option options [Stellar::Account] :to The destination account
+    # @option options [Stellar::Amount] :amount The amount to send
+    def send_payment(options = {})
+      from_account = options[:from]
+      tx_source_account = options[:transaction_source] || from_account
+      op_source_account = from_account if tx_source_account.present?
+
+      sequence = options[:sequence] ||
+        (account_info(tx_source_account).sequence.to_i + 1)
+
+      payment = Stellar::TransactionBuilder.new(
+        source_account: tx_source_account.keypair,
+        sequence_number: sequence
+      ).add_operation(
+        Stellar::Operation.payment(
+          source_account: op_source_account.keypair,
+          destination: options[:to].keypair,
+          amount: options[:amount].to_payment
+        )
+      ).set_memo(options[:memo]).set_timeout(0).build
+
+      signers = [tx_source_account, op_source_account].uniq(&:address)
+      to_envelope_args = signers.map(&:keypair)
+
+      envelope = payment.to_envelope(*to_envelope_args)
+      submit_transaction(tx_envelope: envelope)
+    end
+
+    # @option options [Stellar::Account] :account
+    # @option options [Integer] :limit
+    # @option options [Integer] :cursor
+    # @return [Stellar::TransactionPage]
+    def transactions(options = {})
+      args = options.slice(:limit, :cursor)
+
+      resource = if options[:account]
+        args = args.merge(account_id: options[:account].address)
+        @horizon.account_transactions(args)
+      else
+        @horizon.transactions(args)
+      end
+
+      Stellar::TransactionPage.new(resource)
+    end
+
+    # @param [Array(Symbol,String,Stellar::KeyPair|Stellar::Account)] asset
+    # @param [Stellar::Account] source
+    # @param [Integer] sequence
+    # @param [Integer] fee
+    # @param [Integer] limit
+    def change_trust(
+      asset:,
+      source:,
+      sequence: nil,
+      fee: DEFAULT_FEE,
+      limit: nil
+    )
+      sequence ||= (account_info(source).sequence.to_i + 1)
+
+      op_args = {
+        account: source.keypair,
+        sequence: sequence,
+        line: asset
+      }
+      op_args[:limit] = limit unless limit.nil?
+
+      tx = Stellar::TransactionBuilder.change_trust(
+        source_account: source.keypair,
+        sequence_number: sequence,
+        **op_args
+      )
+
+      envelope = tx.to_envelope(source.keypair)
+      submit_transaction(tx_envelope: envelope)
+    end
+
+    # @param [Stellar::TransactionEnvelope] tx_envelope
+    # @option options [Boolean] :skip_memo_required_check (false)
+    def submit_transaction(tx_envelope:, options: {skip_memo_required_check: false})
+      unless options[:skip_memo_required_check]
+        check_memo_required(tx_envelope)
+      end
+      @horizon.transactions._post(tx: tx_envelope.to_xdr(:base64))
+    end
+
+    # Required by SEP-0029
+    # @param [Stellar::TransactionEnvelope] tx_envelope
+    def check_memo_required(tx_envelope)
+      tx = tx_envelope.tx
+
+      if tx.is_a?(Stellar::FeeBumpTransaction)
+        tx = tx.inner_tx.v1!.tx
+      end
+
+      # Check transactions where the .memo field is nil or of type MemoType.memo_none
+      if !tx.memo.nil? && tx.memo.type != Stellar::MemoType.memo_none
+        return
+      end
+
+      destinations = Set.new
+      ot = Stellar::OperationType
+
+      tx.operations.each_with_index do |op, idx|
+        destination = case op.body.type
+        when ot.payment, ot.path_payment_strict_receive, ot.path_payment_strict_send
+          op.body.value.destination
+        when ot.account_merge
+          # There is no AccountMergeOp, op.body is an Operation object
+          # and op.body.value is a PublicKey (or AccountID) object.
+          op.body.value
+        else
+          next
+        end
+
+        if destinations.include?(destination) || destination.switch == Stellar::CryptoKeyType.key_type_muxed_ed25519
+          next
+        end
+
+        destinations.add(destination)
+        kp = Stellar::KeyPair.from_public_key(destination.value)
+
+        begin
+          info = account_info(kp.address)
+        rescue Faraday::ResourceNotFound
+          # Don't raise an error if its a 404, but throw one otherwise
+          next
+        end
+        if info.data["config.memo_required"] == "MQ=="
+          # MQ== is the base64 encoded string for the string "1"
+          raise AccountRequiresMemoError.new("account requires memo", destination, idx)
+        end
+      end
+    end
+
+    # DEPRECATED: this function has been moved Stellar::SEP10.build_challenge_tx and
+    # will be removed in the next major version release.
+    #
+    # A wrapper function for Stellar::SEP10::build_challenge_tx.
+    #
+    # @param server [Stellar::KeyPair] Keypair for server's signing account.
+    # @param client [Stellar::KeyPair] Keypair for the account whishing to authenticate with the server.
+    # @param anchor_name [String] Anchor's name to be used in the manage_data key.
+    # @param timeout [Integer] Challenge duration (default to 5 minutes).
+    #
+    # @return [String] A base64 encoded string of the raw TransactionEnvelope xdr struct for the transaction.
+    def build_challenge_tx(server:, client:, anchor_name:, timeout: 300)
+      Stellar::SEP10.build_challenge_tx(
+        server: server, client: client, anchor_name: anchor_name, timeout: timeout
+      )
+    end
+
+    # DEPRECATED: this function has been moved to Stellar::SEP10::read_challenge_tx and
+    # will be removed in the next major version release.
+    #
+    # A wrapper function for Stellar::SEP10.verify_challenge_transaction
+    #
+    # @param challenge [String] SEP0010 transaction challenge in base64.
+    # @param server [Stellar::KeyPair] Stellar::KeyPair for server where the challenge was generated.
+    #
+    # @return [Boolean]
+    def verify_challenge_tx(challenge:, server:)
+      Stellar::SEP10.verify_challenge_tx(challenge_xdr: challenge, server: server)
+      true
+    end
+
+    # DEPRECATED: this function has been moved to Stellar::SEP10::verify_tx_signed_by and
+    # will be removed in the next major version release.
+    #
+    # @param transaction_envelope [Stellar::TransactionEnvelope]
+    # @param keypair [Stellar::KeyPair]
+    #
+    # @return [Boolean]
+    #
+    def verify_tx_signed_by(transaction_envelope:, keypair:)
+      Stellar::SEP10.verify_tx_signed_by(
+        tx_envelope: transaction_envelope, keypair: keypair
+      )
+    end
+  end
+end

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_account_info/returns_the_current_details_for_the_account.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_account_info/returns_the_current_details_for_the_account.yml
@@ -1,0 +1,190 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Sun, 04 Mar 2018 12:05:19 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '18000'
+      X-Ratelimit-Remaining:
+      - '17975'
+      X-Ratelimit-Reset:
+      - '277'
+      Content-Length:
+      - '1509'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://horizon-testnet.stellar.org/friendbot{?addr}",
+              "templated": true
+            },
+            "metrics": {
+              "href": "https://horizon-testnet.stellar.org/metrics"
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_issuer,buying_asset_type,buying_asset_code,buying_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "snapshot-snapshots-5-g0d276af",
+          "core_version": "v9.2.0rc2-dirty",
+          "history_latest_ledger": 7732527,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 7732527,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "protocol_version": 9
+        }
+    http_version: 
+  recorded_at: Sun, 04 Mar 2018 12:05:19 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Sun, 04 Mar 2018 12:05:20 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '18000'
+      X-Ratelimit-Remaining:
+      - '17971'
+      X-Ratelimit-Reset:
+      - '208'
+      Content-Length:
+      - '2263'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "paging_token": "",
+          "account_id": "[source_address]",
+          "sequence": "346973227974715",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "3494.9997500",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "[source_address]",
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Sun, 04 Mar 2018 12:05:20 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_account_merge/merges_source_account_into_destination.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_account_merge/merges_source_account_into_destination.yml
@@ -1,0 +1,857 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:12:24 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "accounts": {
+              "href": "https://horizon-testnet.stellar.org/accounts{?signer,asset,cursor,limit,order}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "offer": {
+              "href": "https://horizon-testnet.stellar.org/offers/{offer_id}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/offers{?selling,buying,seller,cursor,limit,order}",
+              "templated": true
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "strict_receive_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-receive{?source_assets,source_account,destination_account,destination_asset_type,destination_asset_issuer,destination_asset_code,destination_amount}",
+              "templated": true
+            },
+            "strict_send_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-send{?destination_account,destination_assets,source_asset_type,source_asset_issuer,source_asset_code,source_amount}",
+              "templated": true
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "1.0.1-2c2d8fb0c3ae0516dcbbb39f189ca00731c9c8c3",
+          "core_version": "stellar-core 12.4.0 (c0136139802ac1a1ac8899424e7888fa9366414e)",
+          "ingest_latest_ledger": 989008,
+          "history_latest_ledger": 989008,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 989008,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "current_protocol_version": 12,
+          "core_supported_protocol_version": 12
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:12:24 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:12:24 GMT
+      Latest-Ledger:
+      - '989008'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2386'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "account_id": "[source_address]",
+          "sequence": "3030756557324305",
+          "subentry_count": 0,
+          "last_modified_ledger": 989000,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9238.7998300",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "[source_address]"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:12:24 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAASAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAUyxhrOP1LHcTXpVGe%2F28d5fERdQF8s6GITwAgOrNpe4AAAAAO5rKAAAAAAAAAAABKATZaAAAAEA%2Bz73VfJXlaMN65inY1qlF6M8YOzKPBYNSdJUYHV74wlcfb0DjvyQAQkCwbm6DUKomTqRIVwaBUVjEyl980rkL
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:12:30 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1307'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/126e9de85218fc1005f75057fb0f3986bae7c696fa7072ccc780d564b0425e8e"
+            }
+          },
+          "hash": "126e9de85218fc1005f75057fb0f3986bae7c696fa7072ccc780d564b0425e8e",
+          "ledger": 989009,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAASAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAUyxhrOP1LHcTXpVGe/28d5fERdQF8s6GITwAgOrNpe4AAAAAO5rKAAAAAAAAAAABKATZaAAAAEA+z73VfJXlaMN65inY1qlF6M8YOzKPBYNSdJUYHV74wlcfb0DjvyQAQkCwbm6DUKomTqRIVwaBUVjEyl980rkL",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XUQAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAVgsD5+AAKxHUAAAARAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XUQAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAVgsD5+AAKxHUAAAASAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMADxdRAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABWCwPn4AArEdQAAABIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdRAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABVHJi/4AArEdQAAABIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAADxdRAAAAAAAAAABTLGGs4/UsdxNelUZ7/bx3l8RF1AXyzoYhPACA6s2l7gAAAAA7msoAAA8XUQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:12:30 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:12:30 GMT
+      Latest-Ledger:
+      - '989009'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2386'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "account_id": "[source_address]",
+          "sequence": "3030756557324306",
+          "subentry_count": 0,
+          "last_modified_ledger": 989009,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9138.7998200",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "[source_address]"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:12:30 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAATAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAx1tP7O9sW71fM8jCCsZwJe5RPHFY9KgPKWZFGqCJ6KcAAAAAO5rKAAAAAAAAAAABKATZaAAAAEDRCTkyEkEKtqPv1nP8yItvsyW%2BOYdOfDEhwmUZD%2Fm4SgCHT1POw9cEZc%2BEc8QLrvPpQB2flr3NLjJ9FgDqXkkO
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:12:35 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1307'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/23121fcce7c452999c27d348bca5285f979cb4a9d264dae013b53095575c7e34"
+            }
+          },
+          "hash": "23121fcce7c452999c27d348bca5285f979cb4a9d264dae013b53095575c7e34",
+          "ledger": 989010,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAATAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAx1tP7O9sW71fM8jCCsZwJe5RPHFY9KgPKWZFGqCJ6KcAAAAAO5rKAAAAAAAAAAABKATZaAAAAEDRCTkyEkEKtqPv1nP8yItvsyW+OYdOfDEhwmUZD/m4SgCHT1POw9cEZc+Ec8QLrvPpQB2flr3NLjJ9FgDqXkkO",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XUgAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAVRyYvlAAKxHUAAAASAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XUgAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAVRyYvlAAKxHUAAAATAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMADxdSAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABVHJi+UAArEdQAAABMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdSAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABULi2WUAArEdQAAABMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAADxdSAAAAAAAAAADHW0/s72xbvV8zyMIKxnAl7lE8cVj0qA8pZkUaoInopwAAAAA7msoAAA8XUgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:12:35 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBJSYYNM4P2SY5YTL2KUM675XR3ZPRCF2QC7FTUGEE6ABAHKZWS64PHB
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:12:35 GMT
+      Latest-Ledger:
+      - '989010'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2385'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBJSYYNM4P2SY5YTL2KUM675XR3ZPRCF2QC7FTUGEE6ABAHKZWS64PHB"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBJSYYNM4P2SY5YTL2KUM675XR3ZPRCF2QC7FTUGEE6ABAHKZWS64PHB/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBJSYYNM4P2SY5YTL2KUM675XR3ZPRCF2QC7FTUGEE6ABAHKZWS64PHB/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBJSYYNM4P2SY5YTL2KUM675XR3ZPRCF2QC7FTUGEE6ABAHKZWS64PHB/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBJSYYNM4P2SY5YTL2KUM675XR3ZPRCF2QC7FTUGEE6ABAHKZWS64PHB/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBJSYYNM4P2SY5YTL2KUM675XR3ZPRCF2QC7FTUGEE6ABAHKZWS64PHB/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBJSYYNM4P2SY5YTL2KUM675XR3ZPRCF2QC7FTUGEE6ABAHKZWS64PHB/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBJSYYNM4P2SY5YTL2KUM675XR3ZPRCF2QC7FTUGEE6ABAHKZWS64PHB/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBJSYYNM4P2SY5YTL2KUM675XR3ZPRCF2QC7FTUGEE6ABAHKZWS64PHB",
+          "account_id": "GBJSYYNM4P2SY5YTL2KUM675XR3ZPRCF2QC7FTUGEE6ABAHKZWS64PHB",
+          "sequence": "4247761310449664",
+          "subentry_count": 0,
+          "last_modified_ledger": 989009,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "100.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GBJSYYNM4P2SY5YTL2KUM675XR3ZPRCF2QC7FTUGEE6ABAHKZWS64PHB",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GBJSYYNM4P2SY5YTL2KUM675XR3ZPRCF2QC7FTUGEE6ABAHKZWS64PHB"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:12:35 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:12:35 GMT
+      Latest-Ledger:
+      - '989010'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2385'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV",
+          "account_id": "GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV",
+          "sequence": "4247765605416960",
+          "subentry_count": 0,
+          "last_modified_ledger": 989010,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "100.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:12:36 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAFMsYazj9Sx3E16VRnv9vHeXxEXUBfLOhiE8AIDqzaXuAAAAZAAPF1EAAAABAAAAAAAAAAAAAAABAAAAAAAAAAgAAAAAx1tP7O9sW71fM8jCCsZwJe5RPHFY9KgPKWZFGqCJ6KcAAAAAAAAAAerNpe4AAABAVkulO7cg44xSLfMjne9exiroHeHPqE4chB1pfS1IE2Eefpm1Junl7Q5coO0kDahe%2B%2F%2FEQf%2BSXiOn2rmulVkoDw%3D%3D
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:12:40 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1367'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/9c86e8c5ca7690ba9e4cf70b2b42b784fb2474a5060bde4e51bd9f723e29907d"
+            }
+          },
+          "hash": "9c86e8c5ca7690ba9e4cf70b2b42b784fb2474a5060bde4e51bd9f723e29907d",
+          "ledger": 989011,
+          "envelope_xdr": "AAAAAFMsYazj9Sx3E16VRnv9vHeXxEXUBfLOhiE8AIDqzaXuAAAAZAAPF1EAAAABAAAAAAAAAAAAAAABAAAAAAAAAAgAAAAAx1tP7O9sW71fM8jCCsZwJe5RPHFY9KgPKWZFGqCJ6KcAAAAAAAAAAerNpe4AAABAVkulO7cg44xSLfMjne9exiroHeHPqE4chB1pfS1IE2Eefpm1Junl7Q5coO0kDahe+//EQf+SXiOn2rmulVkoDw==",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAIAAAAAAAAAAA7msmcAAAAAA==",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XUwAAAAAAAAAAUyxhrOP1LHcTXpVGe/28d5fERdQF8s6GITwAgOrNpe4AAAAAO5rJnAAPF1EAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XUwAAAAAAAAAAUyxhrOP1LHcTXpVGe/28d5fERdQF8s6GITwAgOrNpe4AAAAAO5rJnAAPF1EAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMADxdSAAAAAAAAAADHW0/s72xbvV8zyMIKxnAl7lE8cVj0qA8pZkUaoInopwAAAAA7msoAAA8XUgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdTAAAAAAAAAADHW0/s72xbvV8zyMIKxnAl7lE8cVj0qA8pZkUaoInopwAAAAB3NZOcAA8XUgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMADxdTAAAAAAAAAABTLGGs4/UsdxNelUZ7/bx3l8RF1AXyzoYhPACA6s2l7gAAAAA7msmcAA8XUQAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAFMsYazj9Sx3E16VRnv9vHeXxEXUBfLOhiE8AIDqzaXu"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:12:40 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:12:40 GMT
+      Latest-Ledger:
+      - '989011'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2385'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV",
+          "account_id": "GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV",
+          "sequence": "4247765605416960",
+          "subentry_count": 0,
+          "last_modified_ledger": 989011,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "199.9999900",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GDDVWT7M55WFXPK7GPEMECWGOAS64UJ4OFMPJKAPFFTEKGVARHUKOILV"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:12:40 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_change_trust/given_an_asset_described_as_an_array/creates_updates_or_deletes_a_trustline.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_change_trust/given_an_asset_described_as_an_array/creates_updates_or_deletes_a_trustline.yml
@@ -1,0 +1,1156 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.1
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 17 May 2018 07:04:34 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Content-Length:
+      - '1545'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d585f8daf3c096491274029eedc7aeb051526540674; expires=Fri, 17-May-19
+        07:04:34 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17166'
+      X-Ratelimit-Reset:
+      - '1421'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41c43b0cdc2e6fde-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://horizon-testnet.stellar.org/friendbot{?addr}",
+              "templated": true
+            },
+            "metrics": {
+              "href": "https://horizon-testnet.stellar.org/metrics"
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_issuer,buying_asset_type,buying_asset_code,buying_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "snapshot-cfa216c",
+          "core_version": "stellar-core 9.2.0rc6 (b0923f153b86d394a83b2a619db6b23f07ed0700)",
+          "history_latest_ledger": 9007495,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 9007495,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "protocol_version": 9
+        }
+    http_version: 
+  recorded_at: Thu, 17 May 2018 07:04:34 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.1
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 17 May 2018 07:04:36 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Content-Length:
+      - '2263'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d98d92d1b119a8f6811795f661dc3ea8f1526540676; expires=Fri, 17-May-19
+        07:04:36 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17171'
+      X-Ratelimit-Reset:
+      - '1421'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41c43b1b19a16fc6-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "paging_token": "",
+          "account_id": "[source_address]",
+          "sequence": "346973227974771",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "2166.9991900",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "[source_address]",
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Thu, 17 May 2018 07:04:36 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAKEiSt7wL8zHIfwsJF5PvoI%2FqW7Epb2ihhiW7lxPpHJCAAAAZAABO5IAAAB0AAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAV9B1XeYOKNkASNxCxKZN7Zse4dyKNjJkU26Y%2FAyH5H8AAAAAATEtAAAAAAAAAAABT6RyQgAAAED0b9%2B4u%2FBSi%2Fxmvv2n3fXgqKlqC2Z3YfAig5xUzPaWOZtBjWivz0Xc49fwoUAm6ODgu7aLdmTTddCKJd12zOkM
+    headers:
+      User-Agent:
+      - Faraday v0.15.1
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 17 May 2018 07:04:41 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Content-Length:
+      - '1044'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d8cc5d5e066b217805ab946c0ea60c85a1526540677; expires=Fri, 17-May-19
+        07:04:37 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17165'
+      X-Ratelimit-Reset:
+      - '1418'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41c43b1fbfc36f78-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/031e1dfb135e88e48a83da549e929e109b7b315b25f1d4ead376d650ac0f667d"
+            }
+          },
+          "hash": "031e1dfb135e88e48a83da549e929e109b7b315b25f1d4ead376d650ac0f667d",
+          "ledger": 9007497,
+          "envelope_xdr": "AAAAAKEiSt7wL8zHIfwsJF5PvoI/qW7Epb2ihhiW7lxPpHJCAAAAZAABO5IAAAB0AAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAV9B1XeYOKNkASNxCxKZN7Zse4dyKNjJkU26Y/AyH5H8AAAAAATEtAAAAAAAAAAABT6RyQgAAAED0b9+4u/BSi/xmvv2n3fXgqKlqC2Z3YfAig5xUzPaWOZtBjWivz0Xc49fwoUAm6ODgu7aLdmTTddCKJd12zOkM",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAAAAAAEAAAADAAAAAACJcYkAAAAAAAAAAFfQdV3mDijZAEjcQsSmTe2bHuHcijYyZFNumPwMh+R/AAAAAAExLQAAiXGJAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAwCJcYkAAAAAAAAAAKEiSt7wL8zHIfwsJF5PvoI/qW7Epb2ihhiW7lxPpHJCAAAABQuh1XgAATuSAAAAdAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQCJcYkAAAAAAAAAAKEiSt7wL8zHIfwsJF5PvoI/qW7Epb2ihhiW7lxPpHJCAAAABQpwqHgAATuSAAAAdAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAA"
+        }
+    http_version: 
+  recorded_at: Thu, 17 May 2018 07:04:42 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.1
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 17 May 2018 07:04:43 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Content-Length:
+      - '2262'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=deb345286f671bc53031e1fb55092066c1526540682; expires=Fri, 17-May-19
+        07:04:42 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17164'
+      X-Ratelimit-Reset:
+      - '1412'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41c43b446fe270bc-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+          "paging_token": "",
+          "account_id": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+          "sequence": "38686905033818112",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "2.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+              "weight": 1,
+              "key": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Thu, 17 May 2018 07:04:43 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAFfQdV3mDijZAEjcQsSmTe2bHuHcijYyZFNumPwMh%2BR%2FAAAAZACJcYkAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABQlRDAAAAAAChIkre8C%2FMxyH8LCReT76CP6luxKW9ooYYlu5cT6RyQn%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAEMh%2BR%2FAAAAQHKvzamz6CIQFhD%2Bo4pRbBlUdTrBCLyQqriP1MRKuQ%2FGPJT035gHu4htva6Ws1DgM03DoFcmEo89Jdyw%2FLSigAk%3D
+    headers:
+      User-Agent:
+      - Faraday v0.15.1
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 17 May 2018 07:04:56 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Content-Length:
+      - '1088'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=da23838cb244820c077e69791938444cf1526540691; expires=Fri, 17-May-19
+        07:04:51 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17163'
+      X-Ratelimit-Reset:
+      - '1404'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41c43b79fdaa705c-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/8bc26305ce59485d031f44e19079b382ccd1a5b1aa5b2abc4df900e35655b5fe"
+            }
+          },
+          "hash": "8bc26305ce59485d031f44e19079b382ccd1a5b1aa5b2abc4df900e35655b5fe",
+          "ledger": 9007500,
+          "envelope_xdr": "AAAAAFfQdV3mDijZAEjcQsSmTe2bHuHcijYyZFNumPwMh+R/AAAAZACJcYkAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABQlRDAAAAAAChIkre8C/MxyH8LCReT76CP6luxKW9ooYYlu5cT6RyQn//////////AAAAAAAAAAEMh+R/AAAAQHKvzamz6CIQFhD+o4pRbBlUdTrBCLyQqriP1MRKuQ/GPJT035gHu4htva6Ws1DgM03DoFcmEo89Jdyw/LSigAk=",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAGAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAAAAAAEAAAADAAAAAACJcYwAAAABAAAAAFfQdV3mDijZAEjcQsSmTe2bHuHcijYyZFNumPwMh+R/AAAAAUJUQwAAAAAAoSJK3vAvzMch/CwkXk++gj+pbsSlvaKGGJbuXE+kckIAAAAAAAAAAH//////////AAAAAQAAAAAAAAAAAAAAAwCJcYwAAAAAAAAAAFfQdV3mDijZAEjcQsSmTe2bHuHcijYyZFNumPwMh+R/AAAAAAExLJwAiXGJAAAAAQAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQCJcYwAAAAAAAAAAFfQdV3mDijZAEjcQsSmTe2bHuHcijYyZFNumPwMh+R/AAAAAAExLJwAiXGJAAAAAQAAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAA"
+        }
+    http_version: 
+  recorded_at: Thu, 17 May 2018 07:04:57 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.1
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 17 May 2018 07:04:58 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Content-Length:
+      - '2492'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d0f5a6490d7e2ecba2afecb91d887eda41526540697; expires=Fri, 17-May-19
+        07:04:57 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17162'
+      X-Ratelimit-Reset:
+      - '1397'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41c43b9fec556f78-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+          "paging_token": "",
+          "account_id": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+          "sequence": "38686905033818113",
+          "subentry_count": 1,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "0.0000000",
+              "limit": "922337203685.4775807",
+              "asset_type": "credit_alphanum4",
+              "asset_code": "BTC",
+              "asset_issuer": "[source_address]"
+            },
+            {
+              "balance": "1.9999900",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+              "weight": 1,
+              "key": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Thu, 17 May 2018 07:04:58 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.1
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 17 May 2018 07:04:59 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Content-Length:
+      - '2492'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d6bfc9297175c45e002f404b7d7da3ad91526540699; expires=Fri, 17-May-19
+        07:04:59 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17170'
+      X-Ratelimit-Reset:
+      - '1398'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41c43bab4db36fde-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+          "paging_token": "",
+          "account_id": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+          "sequence": "38686905033818113",
+          "subentry_count": 1,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "0.0000000",
+              "limit": "922337203685.4775807",
+              "asset_type": "credit_alphanum4",
+              "asset_code": "BTC",
+              "asset_issuer": "[source_address]"
+            },
+            {
+              "balance": "1.9999900",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+              "weight": 1,
+              "key": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Thu, 17 May 2018 07:04:59 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAFfQdV3mDijZAEjcQsSmTe2bHuHcijYyZFNumPwMh%2BR%2FAAAAZACJcYkAAAACAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABQlRDAAAAAAChIkre8C%2FMxyH8LCReT76CP6luxKW9ooYYlu5cT6RyQgAAAAA7msoAAAAAAAAAAAEMh%2BR%2FAAAAQOm3v1%2FHlXA2gjgy5NVrqRphjtgkcrG7NsL%2Bppv8K5pFGx6kUDg3x22v8jWgFFi4uSk2qg0hFFnWZgCGeWOOhQg%3D
+    headers:
+      User-Agent:
+      - Faraday v0.15.1
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 17 May 2018 07:05:06 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Content-Length:
+      - '992'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d9c7c0f187fed655141724861965488a41526540704; expires=Fri, 17-May-19
+        07:05:04 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17161'
+      X-Ratelimit-Reset:
+      - '1391'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41c43bcc9842a9ba-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/cd6507987f6605420736ddcb5ac459011d1aeead7bda3e6193aeaa9172cb234b"
+            }
+          },
+          "hash": "cd6507987f6605420736ddcb5ac459011d1aeead7bda3e6193aeaa9172cb234b",
+          "ledger": 9007502,
+          "envelope_xdr": "AAAAAFfQdV3mDijZAEjcQsSmTe2bHuHcijYyZFNumPwMh+R/AAAAZACJcYkAAAACAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABQlRDAAAAAAChIkre8C/MxyH8LCReT76CP6luxKW9ooYYlu5cT6RyQgAAAAA7msoAAAAAAAAAAAEMh+R/AAAAQOm3v1/HlXA2gjgy5NVrqRphjtgkcrG7NsL+ppv8K5pFGx6kUDg3x22v8jWgFFi4uSk2qg0hFFnWZgCGeWOOhQg=",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAGAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAAAAAAEAAAACAAAAAwCJcYwAAAABAAAAAFfQdV3mDijZAEjcQsSmTe2bHuHcijYyZFNumPwMh+R/AAAAAUJUQwAAAAAAoSJK3vAvzMch/CwkXk++gj+pbsSlvaKGGJbuXE+kckIAAAAAAAAAAH//////////AAAAAQAAAAAAAAAAAAAAAQCJcY4AAAABAAAAAFfQdV3mDijZAEjcQsSmTe2bHuHcijYyZFNumPwMh+R/AAAAAUJUQwAAAAAAoSJK3vAvzMch/CwkXk++gj+pbsSlvaKGGJbuXE+kckIAAAAAAAAAAAAAAAA7msoAAAAAAQAAAAAAAAAA"
+        }
+    http_version: 
+  recorded_at: Thu, 17 May 2018 07:05:07 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.1
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 17 May 2018 07:05:09 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Content-Length:
+      - '2483'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d7aac175644da1be092c9ee007f38bdeb1526540708; expires=Fri, 17-May-19
+        07:05:08 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17160'
+      X-Ratelimit-Reset:
+      - '1387'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41c43be249f56f78-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+          "paging_token": "",
+          "account_id": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+          "sequence": "38686905033818114",
+          "subentry_count": 1,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "0.0000000",
+              "limit": "100.0000000",
+              "asset_type": "credit_alphanum4",
+              "asset_code": "BTC",
+              "asset_issuer": "[source_address]"
+            },
+            {
+              "balance": "1.9999800",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+              "weight": 1,
+              "key": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Thu, 17 May 2018 07:05:09 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.1
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 17 May 2018 07:05:10 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Content-Length:
+      - '2483'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d4177802154d1672d8fe6dfc3bbc522001526540709; expires=Fri, 17-May-19
+        07:05:09 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17159'
+      X-Ratelimit-Reset:
+      - '1386'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41c43bec8f707020-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+          "paging_token": "",
+          "account_id": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+          "sequence": "38686905033818114",
+          "subentry_count": 1,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "0.0000000",
+              "limit": "100.0000000",
+              "asset_type": "credit_alphanum4",
+              "asset_code": "BTC",
+              "asset_issuer": "[source_address]"
+            },
+            {
+              "balance": "1.9999800",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+              "weight": 1,
+              "key": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Thu, 17 May 2018 07:05:10 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAFfQdV3mDijZAEjcQsSmTe2bHuHcijYyZFNumPwMh%2BR%2FAAAAZACJcYkAAAADAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABQlRDAAAAAAChIkre8C%2FMxyH8LCReT76CP6luxKW9ooYYlu5cT6RyQgAAAAAAAAAAAAAAAAAAAAEMh%2BR%2FAAAAQOmI76Lcj3hIXz%2B39CZ5GiG9qa4JscrkxFoxwESvENpjy7BkiMc%2BqPZexiKPwdPIRZOhQqrd03P4smCx%2B50y9wc%3D
+    headers:
+      User-Agent:
+      - Faraday v0.15.1
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 17 May 2018 07:05:22 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Content-Length:
+      - '1208'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dcf4915f229bbffee1b72b913357999821526540716; expires=Fri, 17-May-19
+        07:05:16 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17169'
+      X-Ratelimit-Reset:
+      - '1381'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41c43c149f83a9ba-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/c58e9c5258e87f72659c771f4c26dde39bcee8a59d3aff56cc9070c3292198eb"
+            }
+          },
+          "hash": "c58e9c5258e87f72659c771f4c26dde39bcee8a59d3aff56cc9070c3292198eb",
+          "ledger": 9007505,
+          "envelope_xdr": "AAAAAFfQdV3mDijZAEjcQsSmTe2bHuHcijYyZFNumPwMh+R/AAAAZACJcYkAAAADAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABQlRDAAAAAAChIkre8C/MxyH8LCReT76CP6luxKW9ooYYlu5cT6RyQgAAAAAAAAAAAAAAAAAAAAEMh+R/AAAAQOmI76Lcj3hIXz+39CZ5GiG9qa4JscrkxFoxwESvENpjy7BkiMc+qPZexiKPwdPIRZOhQqrd03P4smCx+50y9wc=",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAGAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAAAAAAEAAAAEAAAAAwCJcZEAAAAAAAAAAFfQdV3mDijZAEjcQsSmTe2bHuHcijYyZFNumPwMh+R/AAAAAAExK9QAiXGJAAAAAwAAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQCJcZEAAAAAAAAAAFfQdV3mDijZAEjcQsSmTe2bHuHcijYyZFNumPwMh+R/AAAAAAExK9QAiXGJAAAAAwAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAwCJcY4AAAABAAAAAFfQdV3mDijZAEjcQsSmTe2bHuHcijYyZFNumPwMh+R/AAAAAUJUQwAAAAAAoSJK3vAvzMch/CwkXk++gj+pbsSlvaKGGJbuXE+kckIAAAAAAAAAAAAAAAA7msoAAAAAAQAAAAAAAAAAAAAAAgAAAAEAAAAAV9B1XeYOKNkASNxCxKZN7Zse4dyKNjJkU26Y/AyH5H8AAAABQlRDAAAAAAChIkre8C/MxyH8LCReT76CP6luxKW9ooYYlu5cT6RyQg=="
+        }
+    http_version: 
+  recorded_at: Thu, 17 May 2018 07:05:23 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.1
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 17 May 2018 07:05:23 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Content-Length:
+      - '2262'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d2e129a707ee235f15616365dd6b7fcc21526540723; expires=Fri, 17-May-19
+        07:05:23 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17168'
+      X-Ratelimit-Reset:
+      - '1374'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41c43c42aadb6fd2-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+          "paging_token": "",
+          "account_id": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+          "sequence": "38686905033818115",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "1.9999700",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+              "weight": 1,
+              "key": "GBL5A5K54YHCRWIAJDOEFRFGJXWZWHXB3SFDMMTEKNXJR7AMQ7SH65VY",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Thu, 17 May 2018 07:05:24 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_check_memo_required/doesn_t_raise_an_error_when_a_transaction_has_a_memo.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_check_memo_required/doesn_t_raise_an_error_when_a_transaction_has_a_memo.yml
@@ -1,0 +1,259 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.16.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Mon, 18 May 2020 11:30:15 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "accounts": {
+              "href": "https://horizon-testnet.stellar.org/accounts{?signer,asset,cursor,limit,order}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "fee_stats": {
+              "href": "https://horizon-testnet.stellar.org/fee_stats"
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "ledger": {
+              "href": "https://horizon-testnet.stellar.org/ledger/{sequence}",
+              "templated": true
+            },
+            "ledgers": {
+              "href": "https://horizon-testnet.stellar.org/ledgers{?cursor,limit,order}",
+              "templated": true
+            },
+            "offer": {
+              "href": "https://horizon-testnet.stellar.org/offers/{offer_id}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/offers{?selling,buying,seller,cursor,limit,order}",
+              "templated": true
+            },
+            "operation": {
+              "href": "https://horizon-testnet.stellar.org/operations/{id}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/operations{?cursor,limit,order,include_failed}",
+              "templated": true
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/payments{?cursor,limit,order,include_failed}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "strict_receive_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-receive{?source_assets,source_account,destination_account,destination_asset_type,destination_asset_issuer,destination_asset_code,destination_amount}",
+              "templated": true
+            },
+            "strict_send_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-send{?destination_account,destination_assets,source_asset_type,source_asset_issuer,source_asset_code,source_amount}",
+              "templated": true
+            },
+            "trade_aggregations": {
+              "href": "https://horizon-testnet.stellar.org/trade_aggregations?base_asset_type={base_asset_type}\u0026base_asset_code={base_asset_code}\u0026base_asset_issuer={base_asset_issuer}\u0026counter_asset_type={counter_asset_type}\u0026counter_asset_code={counter_asset_code}\u0026counter_asset_issuer={counter_asset_issuer}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/trades?base_asset_type={base_asset_type}\u0026base_asset_code={base_asset_code}\u0026base_asset_issuer={base_asset_issuer}\u0026counter_asset_type={counter_asset_type}\u0026counter_asset_code={counter_asset_code}\u0026counter_asset_issuer={counter_asset_issuer}",
+              "templated": true
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "1.2.1~unstable-5a1aec3650501a114efedbf81d91dd580a7c8f0e",
+          "core_version": "stellar-core 13.0.0 (9ed3da29be1c2c932b946025ca2907646a9072f4)",
+          "ingest_latest_ledger": 302386,
+          "history_latest_ledger": 302386,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 302387,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "current_protocol_version": 13,
+          "core_supported_protocol_version": 13
+        }
+    http_version: 
+  recorded_at: Mon, 18 May 2020 11:30:15 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.16.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Mon, 18 May 2020 11:30:16 GMT
+      Latest-Ledger:
+      - '302387'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2387'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH",
+          "account_id": "GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH",
+          "sequence": "1298549002207232",
+          "subentry_count": 0,
+          "last_modified_ledger": 302342,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "10000.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH"
+        }
+    http_version: 
+  recorded_at: Mon, 18 May 2020 11:30:16 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_check_memo_required/raises_an_error_for_missing_memo.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_check_memo_required/raises_an_error_for_missing_memo.yml
@@ -1,0 +1,377 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.16.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Mon, 18 May 2020 11:30:11 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '4136'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "accounts": {
+              "href": "https://horizon-testnet.stellar.org/accounts{?signer,asset,cursor,limit,order}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "fee_stats": {
+              "href": "https://horizon-testnet.stellar.org/fee_stats"
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "ledger": {
+              "href": "https://horizon-testnet.stellar.org/ledger/{sequence}",
+              "templated": true
+            },
+            "ledgers": {
+              "href": "https://horizon-testnet.stellar.org/ledgers{?cursor,limit,order}",
+              "templated": true
+            },
+            "offer": {
+              "href": "https://horizon-testnet.stellar.org/offers/{offer_id}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/offers{?selling,buying,seller,cursor,limit,order}",
+              "templated": true
+            },
+            "operation": {
+              "href": "https://horizon-testnet.stellar.org/operations/{id}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/operations{?cursor,limit,order,include_failed}",
+              "templated": true
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/payments{?cursor,limit,order,include_failed}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "strict_receive_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-receive{?source_assets,source_account,destination_account,destination_asset_type,destination_asset_issuer,destination_asset_code,destination_amount}",
+              "templated": true
+            },
+            "strict_send_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-send{?destination_account,destination_assets,source_asset_type,source_asset_issuer,source_asset_code,source_amount}",
+              "templated": true
+            },
+            "trade_aggregations": {
+              "href": "https://horizon-testnet.stellar.org/trade_aggregations?base_asset_type={base_asset_type}\u0026base_asset_code={base_asset_code}\u0026base_asset_issuer={base_asset_issuer}\u0026counter_asset_type={counter_asset_type}\u0026counter_asset_code={counter_asset_code}\u0026counter_asset_issuer={counter_asset_issuer}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/trades?base_asset_type={base_asset_type}\u0026base_asset_code={base_asset_code}\u0026base_asset_issuer={base_asset_issuer}\u0026counter_asset_type={counter_asset_type}\u0026counter_asset_code={counter_asset_code}\u0026counter_asset_issuer={counter_asset_issuer}",
+              "templated": true
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "1.2.1~unstable-5a1aec3650501a114efedbf81d91dd580a7c8f0e",
+          "core_version": "stellar-core 13.0.0 (9ed3da29be1c2c932b946025ca2907646a9072f4)",
+          "ingest_latest_ledger": 302386,
+          "history_latest_ledger": 302386,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 302386,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "current_protocol_version": 13,
+          "core_supported_protocol_version": 13
+        }
+    http_version: 
+  recorded_at: Mon, 18 May 2020 11:30:11 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.16.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Mon, 18 May 2020 11:30:12 GMT
+      Latest-Ledger:
+      - '302386'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2387'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH",
+          "account_id": "GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH",
+          "sequence": "1298549002207232",
+          "subentry_count": 0,
+          "last_modified_ledger": 302342,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "10000.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH"
+        }
+    http_version: 
+  recorded_at: Mon, 18 May 2020 11:30:12 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.16.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Mon, 18 May 2020 11:30:12 GMT
+      Latest-Ledger:
+      - '302386'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2424'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH",
+          "account_id": "GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH",
+          "sequence": "1298454512926721",
+          "subentry_count": 1,
+          "last_modified_ledger": 302337,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9999.9999900",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {
+            "config.memo_required": "MQ=="
+          },
+          "paging_token": "GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH"
+        }
+    http_version: 
+  recorded_at: Mon, 18 May 2020 11:30:12 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_check_memo_required/raises_an_error_for_missing_memo_on_account_merge_operations.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_check_memo_required/raises_an_error_for_missing_memo_on_account_merge_operations.yml
@@ -1,0 +1,377 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.16.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Mon, 18 May 2020 11:30:13 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '4136'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "accounts": {
+              "href": "https://horizon-testnet.stellar.org/accounts{?signer,asset,cursor,limit,order}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "fee_stats": {
+              "href": "https://horizon-testnet.stellar.org/fee_stats"
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "ledger": {
+              "href": "https://horizon-testnet.stellar.org/ledger/{sequence}",
+              "templated": true
+            },
+            "ledgers": {
+              "href": "https://horizon-testnet.stellar.org/ledgers{?cursor,limit,order}",
+              "templated": true
+            },
+            "offer": {
+              "href": "https://horizon-testnet.stellar.org/offers/{offer_id}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/offers{?selling,buying,seller,cursor,limit,order}",
+              "templated": true
+            },
+            "operation": {
+              "href": "https://horizon-testnet.stellar.org/operations/{id}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/operations{?cursor,limit,order,include_failed}",
+              "templated": true
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/payments{?cursor,limit,order,include_failed}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "strict_receive_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-receive{?source_assets,source_account,destination_account,destination_asset_type,destination_asset_issuer,destination_asset_code,destination_amount}",
+              "templated": true
+            },
+            "strict_send_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-send{?destination_account,destination_assets,source_asset_type,source_asset_issuer,source_asset_code,source_amount}",
+              "templated": true
+            },
+            "trade_aggregations": {
+              "href": "https://horizon-testnet.stellar.org/trade_aggregations?base_asset_type={base_asset_type}\u0026base_asset_code={base_asset_code}\u0026base_asset_issuer={base_asset_issuer}\u0026counter_asset_type={counter_asset_type}\u0026counter_asset_code={counter_asset_code}\u0026counter_asset_issuer={counter_asset_issuer}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/trades?base_asset_type={base_asset_type}\u0026base_asset_code={base_asset_code}\u0026base_asset_issuer={base_asset_issuer}\u0026counter_asset_type={counter_asset_type}\u0026counter_asset_code={counter_asset_code}\u0026counter_asset_issuer={counter_asset_issuer}",
+              "templated": true
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "1.2.1~unstable-5a1aec3650501a114efedbf81d91dd580a7c8f0e",
+          "core_version": "stellar-core 13.0.0 (9ed3da29be1c2c932b946025ca2907646a9072f4)",
+          "ingest_latest_ledger": 302386,
+          "history_latest_ledger": 302386,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 302386,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "current_protocol_version": 13,
+          "core_supported_protocol_version": 13
+        }
+    http_version: 
+  recorded_at: Mon, 18 May 2020 11:30:13 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.16.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Mon, 18 May 2020 11:30:13 GMT
+      Latest-Ledger:
+      - '302386'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2387'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH",
+          "account_id": "GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH",
+          "sequence": "1298549002207232",
+          "subentry_count": 0,
+          "last_modified_ledger": 302342,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "10000.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH"
+        }
+    http_version: 
+  recorded_at: Mon, 18 May 2020 11:30:13 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.16.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Mon, 18 May 2020 11:30:14 GMT
+      Latest-Ledger:
+      - '302386'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2424'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH",
+          "account_id": "GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH",
+          "sequence": "1298454512926721",
+          "subentry_count": 1,
+          "last_modified_ledger": 302337,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9999.9999900",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {
+            "config.memo_required": "MQ=="
+          },
+          "paging_token": "GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH"
+        }
+    http_version: 
+  recorded_at: Mon, 18 May 2020 11:30:14 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_check_memo_required/succeeds_with_a_multi-operation_transaction.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_check_memo_required/succeeds_with_a_multi-operation_transaction.yml
@@ -1,0 +1,259 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.16.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Mon, 18 May 2020 11:30:14 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "accounts": {
+              "href": "https://horizon-testnet.stellar.org/accounts{?signer,asset,cursor,limit,order}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "fee_stats": {
+              "href": "https://horizon-testnet.stellar.org/fee_stats"
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "ledger": {
+              "href": "https://horizon-testnet.stellar.org/ledger/{sequence}",
+              "templated": true
+            },
+            "ledgers": {
+              "href": "https://horizon-testnet.stellar.org/ledgers{?cursor,limit,order}",
+              "templated": true
+            },
+            "offer": {
+              "href": "https://horizon-testnet.stellar.org/offers/{offer_id}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/offers{?selling,buying,seller,cursor,limit,order}",
+              "templated": true
+            },
+            "operation": {
+              "href": "https://horizon-testnet.stellar.org/operations/{id}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/operations{?cursor,limit,order,include_failed}",
+              "templated": true
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/payments{?cursor,limit,order,include_failed}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "strict_receive_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-receive{?source_assets,source_account,destination_account,destination_asset_type,destination_asset_issuer,destination_asset_code,destination_amount}",
+              "templated": true
+            },
+            "strict_send_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-send{?destination_account,destination_assets,source_asset_type,source_asset_issuer,source_asset_code,source_amount}",
+              "templated": true
+            },
+            "trade_aggregations": {
+              "href": "https://horizon-testnet.stellar.org/trade_aggregations?base_asset_type={base_asset_type}\u0026base_asset_code={base_asset_code}\u0026base_asset_issuer={base_asset_issuer}\u0026counter_asset_type={counter_asset_type}\u0026counter_asset_code={counter_asset_code}\u0026counter_asset_issuer={counter_asset_issuer}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/trades?base_asset_type={base_asset_type}\u0026base_asset_code={base_asset_code}\u0026base_asset_issuer={base_asset_issuer}\u0026counter_asset_type={counter_asset_type}\u0026counter_asset_code={counter_asset_code}\u0026counter_asset_issuer={counter_asset_issuer}",
+              "templated": true
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "1.2.1~unstable-5a1aec3650501a114efedbf81d91dd580a7c8f0e",
+          "core_version": "stellar-core 13.0.0 (9ed3da29be1c2c932b946025ca2907646a9072f4)",
+          "ingest_latest_ledger": 302386,
+          "history_latest_ledger": 302386,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 302386,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "current_protocol_version": 13,
+          "core_supported_protocol_version": 13
+        }
+    http_version: 
+  recorded_at: Mon, 18 May 2020 11:30:14 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.16.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Mon, 18 May 2020 11:30:15 GMT
+      Latest-Ledger:
+      - '302386'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2387'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH",
+          "account_id": "GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH",
+          "sequence": "1298549002207232",
+          "subentry_count": 0,
+          "last_modified_ledger": 302342,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "10000.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GBUFVANTYQUOGN4EGYECLWZ6ED427VAJKD2JB4JWV47FJ723B6MR5XPH"
+        }
+    http_version: 
+  recorded_at: Mon, 18 May 2020 11:30:15 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_check_memo_required/when_tx_is_fee_bump/raises_an_error_for_missing_memo.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_check_memo_required/when_tx_is_fee_bump/raises_an_error_for_missing_memo.yml
@@ -1,0 +1,491 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.16.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Mon, 18 May 2020 11:30:16 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '4136'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "accounts": {
+              "href": "https://horizon-testnet.stellar.org/accounts{?signer,asset,cursor,limit,order}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "fee_stats": {
+              "href": "https://horizon-testnet.stellar.org/fee_stats"
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "ledger": {
+              "href": "https://horizon-testnet.stellar.org/ledger/{sequence}",
+              "templated": true
+            },
+            "ledgers": {
+              "href": "https://horizon-testnet.stellar.org/ledgers{?cursor,limit,order}",
+              "templated": true
+            },
+            "offer": {
+              "href": "https://horizon-testnet.stellar.org/offers/{offer_id}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/offers{?selling,buying,seller,cursor,limit,order}",
+              "templated": true
+            },
+            "operation": {
+              "href": "https://horizon-testnet.stellar.org/operations/{id}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/operations{?cursor,limit,order,include_failed}",
+              "templated": true
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/payments{?cursor,limit,order,include_failed}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "strict_receive_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-receive{?source_assets,source_account,destination_account,destination_asset_type,destination_asset_issuer,destination_asset_code,destination_amount}",
+              "templated": true
+            },
+            "strict_send_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-send{?destination_account,destination_assets,source_asset_type,source_asset_issuer,source_asset_code,source_amount}",
+              "templated": true
+            },
+            "trade_aggregations": {
+              "href": "https://horizon-testnet.stellar.org/trade_aggregations?base_asset_type={base_asset_type}\u0026base_asset_code={base_asset_code}\u0026base_asset_issuer={base_asset_issuer}\u0026counter_asset_type={counter_asset_type}\u0026counter_asset_code={counter_asset_code}\u0026counter_asset_issuer={counter_asset_issuer}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/trades?base_asset_type={base_asset_type}\u0026base_asset_code={base_asset_code}\u0026base_asset_issuer={base_asset_issuer}\u0026counter_asset_type={counter_asset_type}\u0026counter_asset_code={counter_asset_code}\u0026counter_asset_issuer={counter_asset_issuer}",
+              "templated": true
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "1.2.1~unstable-5a1aec3650501a114efedbf81d91dd580a7c8f0e",
+          "core_version": "stellar-core 13.0.0 (9ed3da29be1c2c932b946025ca2907646a9072f4)",
+          "ingest_latest_ledger": 302387,
+          "history_latest_ledger": 302387,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 302387,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "current_protocol_version": 13,
+          "core_supported_protocol_version": 13
+        }
+    http_version: 
+  recorded_at: Mon, 18 May 2020 11:30:16 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GDKRKBSIEJ5TREX6HUK2E6XIU6IK3EXHAPUSK6DXVLZNNJFUKTQYD7K6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.16.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Mon, 18 May 2020 11:30:17 GMT
+      Latest-Ledger:
+      - '302387'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2387'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDKRKBSIEJ5TREX6HUK2E6XIU6IK3EXHAPUSK6DXVLZNNJFUKTQYD7K6"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDKRKBSIEJ5TREX6HUK2E6XIU6IK3EXHAPUSK6DXVLZNNJFUKTQYD7K6/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDKRKBSIEJ5TREX6HUK2E6XIU6IK3EXHAPUSK6DXVLZNNJFUKTQYD7K6/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDKRKBSIEJ5TREX6HUK2E6XIU6IK3EXHAPUSK6DXVLZNNJFUKTQYD7K6/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDKRKBSIEJ5TREX6HUK2E6XIU6IK3EXHAPUSK6DXVLZNNJFUKTQYD7K6/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDKRKBSIEJ5TREX6HUK2E6XIU6IK3EXHAPUSK6DXVLZNNJFUKTQYD7K6/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDKRKBSIEJ5TREX6HUK2E6XIU6IK3EXHAPUSK6DXVLZNNJFUKTQYD7K6/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDKRKBSIEJ5TREX6HUK2E6XIU6IK3EXHAPUSK6DXVLZNNJFUKTQYD7K6/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GDKRKBSIEJ5TREX6HUK2E6XIU6IK3EXHAPUSK6DXVLZNNJFUKTQYD7K6",
+          "account_id": "GDKRKBSIEJ5TREX6HUK2E6XIU6IK3EXHAPUSK6DXVLZNNJFUKTQYD7K6",
+          "sequence": "1098115763404800",
+          "subentry_count": 0,
+          "last_modified_ledger": 255675,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "10000.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GDKRKBSIEJ5TREX6HUK2E6XIU6IK3EXHAPUSK6DXVLZNNJFUKTQYD7K6",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GDKRKBSIEJ5TREX6HUK2E6XIU6IK3EXHAPUSK6DXVLZNNJFUKTQYD7K6"
+        }
+    http_version: 
+  recorded_at: Mon, 18 May 2020 11:30:17 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GAN5632K757IKNNROZGPKEFMFTETGXSBH5JCD52NCBXPFFQSVSXJJ32W
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.16.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Mon, 18 May 2020 11:30:18 GMT
+      Latest-Ledger:
+      - '302387'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2387'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAN5632K757IKNNROZGPKEFMFTETGXSBH5JCD52NCBXPFFQSVSXJJ32W"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAN5632K757IKNNROZGPKEFMFTETGXSBH5JCD52NCBXPFFQSVSXJJ32W/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAN5632K757IKNNROZGPKEFMFTETGXSBH5JCD52NCBXPFFQSVSXJJ32W/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAN5632K757IKNNROZGPKEFMFTETGXSBH5JCD52NCBXPFFQSVSXJJ32W/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAN5632K757IKNNROZGPKEFMFTETGXSBH5JCD52NCBXPFFQSVSXJJ32W/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAN5632K757IKNNROZGPKEFMFTETGXSBH5JCD52NCBXPFFQSVSXJJ32W/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAN5632K757IKNNROZGPKEFMFTETGXSBH5JCD52NCBXPFFQSVSXJJ32W/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAN5632K757IKNNROZGPKEFMFTETGXSBH5JCD52NCBXPFFQSVSXJJ32W/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GAN5632K757IKNNROZGPKEFMFTETGXSBH5JCD52NCBXPFFQSVSXJJ32W",
+          "account_id": "GAN5632K757IKNNROZGPKEFMFTETGXSBH5JCD52NCBXPFFQSVSXJJ32W",
+          "sequence": "1097673381773312",
+          "subentry_count": 0,
+          "last_modified_ledger": 255572,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "10000.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GAN5632K757IKNNROZGPKEFMFTETGXSBH5JCD52NCBXPFFQSVSXJJ32W",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GAN5632K757IKNNROZGPKEFMFTETGXSBH5JCD52NCBXPFFQSVSXJJ32W"
+        }
+    http_version: 
+  recorded_at: Mon, 18 May 2020 11:30:18 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.16.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Mon, 18 May 2020 11:30:18 GMT
+      Latest-Ledger:
+      - '302387'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2424'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH",
+          "account_id": "GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH",
+          "sequence": "1298454512926721",
+          "subentry_count": 1,
+          "last_modified_ledger": 302337,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9999.9999900",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {
+            "config.memo_required": "MQ=="
+          },
+          "paging_token": "GA7Y7OCKQHW3CRG73JFFUUB4KDAN5AWV6WF7QIBEEMZ43DGPVRTJMGAH"
+        }
+    http_version: 
+  recorded_at: Mon, 18 May 2020 11:30:18 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_create_account/creates_the_account.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_create_account/creates_the_account.yml
@@ -1,0 +1,323 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Sun, 26 Mar 2017 07:28:39 GMT
+      X-Ratelimit-Limit:
+      - '72000'
+      X-Ratelimit-Remaining:
+      - '71950'
+      X-Ratelimit-Reset:
+      - '2166'
+      Content-Length:
+      - '1366'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://horizon-testnet.stellar.org/friendbot{?addr}",
+              "templated": true
+            },
+            "metrics": {
+              "href": "https://horizon-testnet.stellar.org/metrics"
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_issuer,buying_asset_type,buying_asset_code,buying_issuer}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "v0.10.0-3-g50eda21",
+          "core_version": "v0.6.1-2-g12a1603",
+          "history_latest_ledger": 124857,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 124857,
+          "core_elder_ledger": 1,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "protocol_version": 4
+        }
+    http_version: 
+  recorded_at: Sun, 26 Mar 2017 07:28:38 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Sun, 26 Mar 2017 07:28:40 GMT
+      X-Ratelimit-Limit:
+      - '72000'
+      X-Ratelimit-Remaining:
+      - '71949'
+      X-Ratelimit-Reset:
+      - '2165'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "paging_token": "",
+          "account_id": "[source_address]",
+          "sequence": "346973227974693",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "4949.9998600",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "[source_address]",
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Sun, 26 Mar 2017 07:28:39 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAKEiSt7wL8zHIfwsJF5PvoI%2FqW7Epb2ihhiW7lxPpHJCO5rKAAABO5IAAAAmAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA3thuBcDVJ%2B1nsrzNBZUsTXSzLqe%2F1uSLB3pCUNbLLccAAAAAO5rKAAAAAAAAAAABT6RyQgAAAED%2F4yyK21dzG2s7fEVNMeqQ%2FIjH12yPb%2FokUABPH3l%2FDxzTYgkWMC1V2MD4pV%2FpcqAbRrwWp6AUoTvjiE%2BhqF4C
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Sun, 26 Mar 2017 07:28:46 GMT
+      X-Ratelimit-Limit:
+      - '72000'
+      X-Ratelimit-Remaining:
+      - '71948'
+      X-Ratelimit-Reset:
+      - '2164'
+      Content-Length:
+      - '915'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/c56288996ef30a6677716d1c12879911076cd49984b997226b7d6e85105bb792"
+            }
+          },
+          "hash": "c56288996ef30a6677716d1c12879911076cd49984b997226b7d6e85105bb792",
+          "ledger": 124860,
+          "envelope_xdr": "AAAAAKEiSt7wL8zHIfwsJF5PvoI/qW7Epb2ihhiW7lxPpHJCO5rKAAABO5IAAAAmAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA3thuBcDVJ+1nsrzNBZUsTXSzLqe/1uSLB3pCUNbLLccAAAAAO5rKAAAAAAAAAAABT6RyQgAAAED/4yyK21dzG2s7fEVNMeqQ/IjH12yPb/okUABPH3l/DxzTYgkWMC1V2MD4pV/pcqAbRrwWp6AUoTvjiE+hqF4C",
+          "result_xdr": "AAAAADuaygAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAAAAAAEAAAACAAAAAAAB57wAAAAAAAAAAN7YbgXA1SftZ7K8zQWVLE10sy6nv9bkiwd6QlDWyy3HAAAAADuaygAAAee8AAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQAB57wAAAAAAAAAAKEiSt7wL8zHIfwsJF5PvoI/qW7Epb2ihhiW7lxPpHJCAAAACw84dYgAATuSAAAAJgAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAA"
+        }
+    http_version: 
+  recorded_at: Sun, 26 Mar 2017 07:28:45 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GDPNQ3QFYDKSP3LHWK6M2BMVFRGXJMZOU675NZELA55EEUGWZMW4OGMC
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Sun, 26 Mar 2017 07:28:47 GMT
+      X-Ratelimit-Limit:
+      - '72000'
+      X-Ratelimit-Remaining:
+      - '71947'
+      X-Ratelimit-Reset:
+      - '2158'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDPNQ3QFYDKSP3LHWK6M2BMVFRGXJMZOU675NZELA55EEUGWZMW4OGMC"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDPNQ3QFYDKSP3LHWK6M2BMVFRGXJMZOU675NZELA55EEUGWZMW4OGMC/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDPNQ3QFYDKSP3LHWK6M2BMVFRGXJMZOU675NZELA55EEUGWZMW4OGMC/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDPNQ3QFYDKSP3LHWK6M2BMVFRGXJMZOU675NZELA55EEUGWZMW4OGMC/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDPNQ3QFYDKSP3LHWK6M2BMVFRGXJMZOU675NZELA55EEUGWZMW4OGMC/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDPNQ3QFYDKSP3LHWK6M2BMVFRGXJMZOU675NZELA55EEUGWZMW4OGMC/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDPNQ3QFYDKSP3LHWK6M2BMVFRGXJMZOU675NZELA55EEUGWZMW4OGMC/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDPNQ3QFYDKSP3LHWK6M2BMVFRGXJMZOU675NZELA55EEUGWZMW4OGMC/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GDPNQ3QFYDKSP3LHWK6M2BMVFRGXJMZOU675NZELA55EEUGWZMW4OGMC",
+          "paging_token": "",
+          "account_id": "GDPNQ3QFYDKSP3LHWK6M2BMVFRGXJMZOU675NZELA55EEUGWZMW4OGMC",
+          "sequence": "536269616578560",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "100.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GDPNQ3QFYDKSP3LHWK6M2BMVFRGXJMZOU675NZELA55EEUGWZMW4OGMC",
+              "weight": 1,
+              "key": "GDPNQ3QFYDKSP3LHWK6M2BMVFRGXJMZOU675NZELA55EEUGWZMW4OGMC",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Sun, 26 Mar 2017 07:28:46 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_friendbot/requests_for_XLM_from_a_friendbot.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_friendbot/requests_for_XLM_from_a_friendbot.yml
@@ -1,0 +1,246 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://friendbot.stellar.org/?addr=GCVV6PPVRMBSNMC3CXLYVF5IR3M4EWZJMPHMB6H6GGLJKZQUQXHHWLH7
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Length:
+      - '0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Wed, 27 Feb 2019 13:37:42 GMT
+      Vary:
+      - Origin
+      Content-Length:
+      - '1305'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/2b860ac7335b9dba1731c2398ac3a2791521397ccc619ee0381edf705bb132ef"
+            }
+          },
+          "hash": "2b860ac7335b9dba1731c2398ac3a2791521397ccc619ee0381edf705bb132ef",
+          "ledger": 2626,
+          "envelope_xdr": "AAAAABB90WssODNIgi6BHveqzxTRmIpvAFRyVNM+Hm2GVuCcAAAAZAAABD0AAALWAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAq1899YsDJrBbFdeKl6iO2cJbKWPOwPj+MZaVZhSFznsAAAAXSHboAAAAAAAAAAABhlbgnAAAAEBJDTZxL0wLfR8Jn1DsY5mqUM+g0e6Va9LVSqcWMRBu3JXukA43VIBhMinuyFG3CJ9t82eWlOV8WqCyGZbKZLQM",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAAAKQgAAAAAAAAAAEH3Rayw4M0iCLoEe96rPFNGYim8AVHJU0z4ebYZW4JwAA1UD3FScaAAABD0AAALVAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAKQgAAAAAAAAAAEH3Rayw4M0iCLoEe96rPFNGYim8AVHJU0z4ebYZW4JwAA1UD3FScaAAABD0AAALWAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMAAApCAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAADVQPcVJxoAAAEPQAAAtYAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAApCAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAADVOyT3bRoAAAEPQAAAtYAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAApCAAAAAAAAAACrXz31iwMmsFsV14qXqI7ZwlspY87A+P4xlpVmFIXOewAAABdIdugAAAAKQgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Wed, 27 Feb 2019 13:37:42 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Wed, 27 Feb 2019 13:37:44 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1615'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "metrics": {
+              "href": "https://horizon-testnet.stellar.org/metrics"
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "0.17.0-f510ce5a0450f1fab1576f248a8a9f7a9ec3aaf7",
+          "core_version": "stellar-core 10.2.0 (54504c714ab6e696283e0bd0fdf1c3a029b7c88b)",
+          "history_latest_ledger": 2626,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 2626,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "current_protocol_version": 10,
+          "core_supported_protocol_version": 10
+        }
+    http_version: 
+  recorded_at: Wed, 27 Feb 2019 13:37:44 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GCVV6PPVRMBSNMC3CXLYVF5IR3M4EWZJMPHMB6H6GGLJKZQUQXHHWLH7
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Wed, 27 Feb 2019 13:37:45 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2295'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCVV6PPVRMBSNMC3CXLYVF5IR3M4EWZJMPHMB6H6GGLJKZQUQXHHWLH7"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCVV6PPVRMBSNMC3CXLYVF5IR3M4EWZJMPHMB6H6GGLJKZQUQXHHWLH7/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCVV6PPVRMBSNMC3CXLYVF5IR3M4EWZJMPHMB6H6GGLJKZQUQXHHWLH7/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCVV6PPVRMBSNMC3CXLYVF5IR3M4EWZJMPHMB6H6GGLJKZQUQXHHWLH7/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCVV6PPVRMBSNMC3CXLYVF5IR3M4EWZJMPHMB6H6GGLJKZQUQXHHWLH7/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCVV6PPVRMBSNMC3CXLYVF5IR3M4EWZJMPHMB6H6GGLJKZQUQXHHWLH7/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCVV6PPVRMBSNMC3CXLYVF5IR3M4EWZJMPHMB6H6GGLJKZQUQXHHWLH7/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCVV6PPVRMBSNMC3CXLYVF5IR3M4EWZJMPHMB6H6GGLJKZQUQXHHWLH7/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GCVV6PPVRMBSNMC3CXLYVF5IR3M4EWZJMPHMB6H6GGLJKZQUQXHHWLH7",
+          "paging_token": "",
+          "account_id": "GCVV6PPVRMBSNMC3CXLYVF5IR3M4EWZJMPHMB6H6GGLJKZQUQXHHWLH7",
+          "sequence": "11278584119296",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "10000.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GCVV6PPVRMBSNMC3CXLYVF5IR3M4EWZJMPHMB6H6GGLJKZQUQXHHWLH7",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Wed, 27 Feb 2019 13:37:45 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_load_account/loads_successfully.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_load_account/loads_successfully.yml
@@ -1,0 +1,226 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.7.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Mon, 16 Mar 2020 19:16:40 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2496'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "accounts": {
+              "href": "https://horizon-testnet.stellar.org/accounts{?signer,asset,cursor,limit,order}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "offer": {
+              "href": "https://horizon-testnet.stellar.org/offers/{offer_id}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/offers{?selling,buying,seller,cursor,limit,order}",
+              "templated": true
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "strict_receive_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-receive{?source_assets,source_account,destination_account,destination_asset_type,destination_asset_issuer,destination_asset_code,destination_amount}",
+              "templated": true
+            },
+            "strict_send_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-send{?destination_account,destination_assets,source_asset_type,source_asset_issuer,source_asset_code,source_amount}",
+              "templated": true
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "1.0.0-948d8d1221abd4f15cac2d3a9eb44b31633cd3b9",
+          "core_version": "stellar-core 12.4.0 (c0136139802ac1a1ac8899424e7888fa9366414e)",
+          "ingest_latest_ledger": 751444,
+          "history_latest_ledger": 751444,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 751444,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "current_protocol_version": 12,
+          "core_supported_protocol_version": 12
+        }
+    http_version: 
+  recorded_at: Mon, 16 Mar 2020 19:16:40 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.7.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Mon, 16 Mar 2020 19:16:41 GMT
+      Latest-Ledger:
+      - '751444'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2386'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "account_id": "[source_address]",
+          "sequence": "3030756557324294",
+          "subentry_count": 0,
+          "last_modified_ledger": 705785,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9745.8999400",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "[source_address]"
+        }
+    http_version: 
+  recorded_at: Mon, 16 Mar 2020 19:16:41 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_send_payment/alphanum12_asset/sends_a_alphanum12_asset_to_the_destination.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_send_payment/alphanum12_asset/sends_a_alphanum12_asset_to_the_destination.yml
@@ -1,0 +1,881 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:10:56 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2496'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "accounts": {
+              "href": "https://horizon-testnet.stellar.org/accounts{?signer,asset,cursor,limit,order}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "offer": {
+              "href": "https://horizon-testnet.stellar.org/offers/{offer_id}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/offers{?selling,buying,seller,cursor,limit,order}",
+              "templated": true
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "strict_receive_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-receive{?source_assets,source_account,destination_account,destination_asset_type,destination_asset_issuer,destination_asset_code,destination_amount}",
+              "templated": true
+            },
+            "strict_send_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-send{?destination_account,destination_assets,source_asset_type,source_asset_issuer,source_asset_code,source_amount}",
+              "templated": true
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "1.0.1-2c2d8fb0c3ae0516dcbbb39f189ca00731c9c8c3",
+          "core_version": "stellar-core 12.4.0 (c0136139802ac1a1ac8899424e7888fa9366414e)",
+          "ingest_latest_ledger": 988991,
+          "history_latest_ledger": 988991,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 988991,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "current_protocol_version": 12,
+          "core_supported_protocol_version": 12
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:10:56 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:10:57 GMT
+      Latest-Ledger:
+      - '988991'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2386'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "account_id": "[source_address]",
+          "sequence": "3030756557324298",
+          "subentry_count": 0,
+          "last_modified_ledger": 988991,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9493.8999000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "[source_address]"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:10:57 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAALAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAxmiQHRP0YXQnHxZhib5fcfqDSx8MJpJVJMDZzVGIan4AAAAAATEtAAAAAAAAAAABKATZaAAAAEAH85uy9aG0rTTWzByhSjL4Tr45fHsC%2Fj%2BrhgoH%2FDbQVYJp8yeJpQGSk05Tu8FvVq6ZcLNxcEOtGPHu%2Fgt3l3MF
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:01 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1307'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/affdba4d060e4bcc06fdf3fd355aaffeb68529c2475a3fe18758938767771da4"
+            }
+          },
+          "hash": "affdba4d060e4bcc06fdf3fd355aaffeb68529c2475a3fe18758938767771da4",
+          "ledger": 988992,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAALAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAxmiQHRP0YXQnHxZhib5fcfqDSx8MJpJVJMDZzVGIan4AAAAAATEtAAAAAAAAAAABKATZaAAAAEAH85uy9aG0rTTWzByhSjL4Tr45fHsC/j+rhgoH/DbQVYJp8yeJpQGSk05Tu8FvVq6ZcLNxcEOtGPHu/gt3l3MF",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XQAAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAWGs4odAAKxHUAAAAKAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XQAAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAWGs4odAAKxHUAAAALAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMADxdAAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABYazih0AArEdQAAAAsAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdAAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABYZnPt0AArEdQAAAAsAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAADxdAAAAAAAAAAADGaJAdE/RhdCcfFmGJvl9x+oNLHwwmklUkwNnNUYhqfgAAAAABMS0AAA8XQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:01 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:01 GMT
+      Latest-Ledger:
+      - '988992'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2383'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R",
+          "account_id": "GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R",
+          "sequence": "4247688296005632",
+          "subentry_count": 0,
+          "last_modified_ledger": 988992,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "2.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:01 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAMZokB0T9GF0Jx8WYYm%2BX3H6g0sfDCaSVSTA2c1RiGp%2BAAAAZAAPF0AAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAACTE9OR05BTUUAAAAAAAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNlof%2F%2F%2F%2F%2F%2F%2F%2F%2F8AAAAAAAAAAVGIan4AAABAq35xshDUbQzlSUYpNjXxhEiLo%2BlNrz8T%2BoUGe4w44XM7c4xfJRNzzNpqJ%2B17ymjrUbZZmNsF%2BPS37dAZaszyCA%3D%3D
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:06 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1371'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/e4599f57f0bea0a878259bb94f1018f49fb6a4749add2b2f368a99153498a71e"
+            }
+          },
+          "hash": "e4599f57f0bea0a878259bb94f1018f49fb6a4749add2b2f368a99153498a71e",
+          "ledger": 988993,
+          "envelope_xdr": "AAAAAMZokB0T9GF0Jx8WYYm+X3H6g0sfDCaSVSTA2c1RiGp+AAAAZAAPF0AAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAACTE9OR05BTUUAAAAAAAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNlof/////////8AAAAAAAAAAVGIan4AAABAq35xshDUbQzlSUYpNjXxhEiLo+lNrz8T+oUGe4w44XM7c4xfJRNzzNpqJ+17ymjrUbZZmNsF+PS37dAZaszyCA==",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAGAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XQQAAAAAAAAAAxmiQHRP0YXQnHxZhib5fcfqDSx8MJpJVJMDZzVGIan4AAAAAATEsnAAPF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XQQAAAAAAAAAAxmiQHRP0YXQnHxZhib5fcfqDSx8MJpJVJMDZzVGIan4AAAAAATEsnAAPF0AAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMADxdBAAAAAAAAAADGaJAdE/RhdCcfFmGJvl9x+oNLHwwmklUkwNnNUYhqfgAAAAABMSycAA8XQAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdBAAAAAAAAAADGaJAdE/RhdCcfFmGJvl9x+oNLHwwmklUkwNnNUYhqfgAAAAABMSycAA8XQAAAAAEAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAADxdBAAAAAQAAAADGaJAdE/RhdCcfFmGJvl9x+oNLHwwmklUkwNnNUYhqfgAAAAJMT05HTkFNRQAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAAAAAAAH//////////AAAAAQAAAAAAAAAA"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:06 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:06 GMT
+      Latest-Ledger:
+      - '988993'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2386'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "account_id": "[source_address]",
+          "sequence": "3030756557324299",
+          "subentry_count": 0,
+          "last_modified_ledger": 988992,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9491.8998900",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "[source_address]"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:06 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:06 GMT
+      Latest-Ledger:
+      - '988993'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2769'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R",
+          "account_id": "GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R",
+          "sequence": "4247688296005633",
+          "subentry_count": 1,
+          "last_modified_ledger": 988993,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "0.0000000",
+              "limit": "922337203685.4775807",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "last_modified_ledger": 988993,
+              "is_authorized": true,
+              "asset_type": "credit_alphanum12",
+              "asset_code": "LONGNAME",
+              "asset_issuer": "[source_address]"
+            },
+            {
+              "balance": "1.9999900",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:06 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAAMAAAAAAAAAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa%2FVa29KATZaAAAAAEAAAAAxmiQHRP0YXQnHxZhib5fcfqDSx8MJpJVJMDZzVGIan4AAAACTE9OR05BTUUAAAAAAAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAAFloLwAAAAAAAAAAASgE2WgAAABAv%2BOANxJWAK54Q9DccXgv8Dayl99uIkPuG9xaIvI3u98%2F%2FhPaNNgtcHvQKBJB6zZDuweUrRq6MjpDd9o2tAVyAA%3D%3D
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:12 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1383'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/a481b537e48c6b7fc9bfebc03abfe5f40407bce54b3d0078ce6be9ab7815ed18"
+            }
+          },
+          "hash": "a481b537e48c6b7fc9bfebc03abfe5f40407bce54b3d0078ce6be9ab7815ed18",
+          "ledger": 988994,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAAMAAAAAAAAAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAAEAAAAAxmiQHRP0YXQnHxZhib5fcfqDSx8MJpJVJMDZzVGIan4AAAACTE9OR05BTUUAAAAAAAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAAFloLwAAAAAAAAAAASgE2WgAAABAv+OANxJWAK54Q9DccXgv8Dayl99uIkPuG9xaIvI3u98//hPaNNgtcHvQKBJB6zZDuweUrRq6MjpDd9o2tAVyAA==",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XQgAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAWGZz7EAAKxHUAAAALAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XQgAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAWGZz7EAAKxHUAAAAMAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAgAAAAMADxdBAAAAAQAAAADGaJAdE/RhdCcfFmGJvl9x+oNLHwwmklUkwNnNUYhqfgAAAAJMT05HTkFNRQAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAAAAAAAH//////////AAAAAQAAAAAAAAAAAAAAAQAPF0IAAAABAAAAAMZokB0T9GF0Jx8WYYm+X3H6g0sfDCaSVSTA2c1RiGp+AAAAAkxPTkdOQU1FAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAABZaC8Af/////////8AAAABAAAAAAAAAAA="
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:12 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:12 GMT
+      Latest-Ledger:
+      - '988994'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2771'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R",
+          "account_id": "GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R",
+          "sequence": "4247688296005633",
+          "subentry_count": 1,
+          "last_modified_ledger": 988993,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "150.0000000",
+              "limit": "922337203685.4775807",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "last_modified_ledger": 988994,
+              "is_authorized": true,
+              "asset_type": "credit_alphanum12",
+              "asset_code": "LONGNAME",
+              "asset_issuer": "[source_address]"
+            },
+            {
+              "balance": "1.9999900",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GDDGREA5CP2GC5BHD4LGDCN6L5Y7VA2LD4GCNESVETANTTKRRBVH4F2R"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:12 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_send_payment/alphanum4_asset/sends_a_alphanum4_asset_to_the_destination.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_send_payment/alphanum4_asset/sends_a_alphanum4_asset_to_the_destination.yml
@@ -1,0 +1,881 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:10:41 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2496'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "accounts": {
+              "href": "https://horizon-testnet.stellar.org/accounts{?signer,asset,cursor,limit,order}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "offer": {
+              "href": "https://horizon-testnet.stellar.org/offers/{offer_id}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/offers{?selling,buying,seller,cursor,limit,order}",
+              "templated": true
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "strict_receive_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-receive{?source_assets,source_account,destination_account,destination_asset_type,destination_asset_issuer,destination_asset_code,destination_amount}",
+              "templated": true
+            },
+            "strict_send_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-send{?destination_account,destination_assets,source_asset_type,source_asset_issuer,source_asset_code,source_amount}",
+              "templated": true
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "1.0.1-2c2d8fb0c3ae0516dcbbb39f189ca00731c9c8c3",
+          "core_version": "stellar-core 12.4.0 (c0136139802ac1a1ac8899424e7888fa9366414e)",
+          "ingest_latest_ledger": 988988,
+          "history_latest_ledger": 988988,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 988988,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "current_protocol_version": 12,
+          "core_supported_protocol_version": 12
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:10:42 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:10:42 GMT
+      Latest-Ledger:
+      - '988988'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2386'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "account_id": "[source_address]",
+          "sequence": "3030756557324296",
+          "subentry_count": 0,
+          "last_modified_ledger": 988988,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9495.8999200",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "[source_address]"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:10:42 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAAJAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAACobCYlYwG0X7ZeQD4rm0A4THckLdjxTVIKTCu9PyUIkAAAAAATEtAAAAAAAAAAABKATZaAAAAEAYteTzZs3ACY03Y0EpBzyqc77PxofoR3BwfLcYy7KSZnis7REIbxIJ4vq5gYR0rMCZrKsChihul1%2FEnmY7nhsG
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:10:46 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1307'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/ec895886aa83980a66b79a579b076489977c790759a01c5558f076a8ac659a37"
+            }
+          },
+          "hash": "ec895886aa83980a66b79a579b076489977c790759a01c5558f076a8ac659a37",
+          "ledger": 988989,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAAJAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAACobCYlYwG0X7ZeQD4rm0A4THckLdjxTVIKTCu9PyUIkAAAAAATEtAAAAAAAAAAABKATZaAAAAEAYteTzZs3ACY03Y0EpBzyqc77PxofoR3BwfLcYy7KSZnis7REIbxIJ4vq5gYR0rMCZrKsChihul1/EnmY7nhsG",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XPQAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAWG/9WPAAKxHUAAAAIAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XPQAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAWG/9WPAAKxHUAAAAJAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMADxc9AAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABYb/1Y8AArEdQAAAAkAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxc9AAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABYazik8AArEdQAAAAkAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAADxc9AAAAAAAAAAAKhsJiVjAbRftl5APiubQDhMdyQt2PFNUgpMK70/JQiQAAAAABMS0AAA8XPQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:10:46 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:10:46 GMT
+      Latest-Ledger:
+      - '988989'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2383'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4",
+          "account_id": "GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4",
+          "sequence": "4247675411103744",
+          "subentry_count": 0,
+          "last_modified_ledger": 988989,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "2.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:10:46 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAAqGwmJWMBtF%2B2XkA%2BK5tAOEx3JC3Y8U1SCkwrvT8lCJAAAAZAAPFz0AAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABQlRDAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa%2FVa29KATZaH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAHT8lCJAAAAQIi9MdbGa3ykX08gyx2IqoZ7mMuSmdjWMutRJZWp2MVjJ1f%2BL%2Feutry1K12AX%2BA2WjtYlaqzovg2Z1Tsal2LcAk%3D
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:10:51 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1351'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/b4415c1418abb02d0beb06ace6d954d6384924ecd770421d8814a9649fbd0953"
+            }
+          },
+          "hash": "b4415c1418abb02d0beb06ace6d954d6384924ecd770421d8814a9649fbd0953",
+          "ledger": 988990,
+          "envelope_xdr": "AAAAAAqGwmJWMBtF+2XkA+K5tAOEx3JC3Y8U1SCkwrvT8lCJAAAAZAAPFz0AAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABQlRDAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaH//////////AAAAAAAAAAHT8lCJAAAAQIi9MdbGa3ykX08gyx2IqoZ7mMuSmdjWMutRJZWp2MVjJ1f+L/eutry1K12AX+A2WjtYlaqzovg2Z1Tsal2LcAk=",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAGAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XPgAAAAAAAAAACobCYlYwG0X7ZeQD4rm0A4THckLdjxTVIKTCu9PyUIkAAAAAATEsnAAPFz0AAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XPgAAAAAAAAAACobCYlYwG0X7ZeQD4rm0A4THckLdjxTVIKTCu9PyUIkAAAAAATEsnAAPFz0AAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMADxc+AAAAAAAAAAAKhsJiVjAbRftl5APiubQDhMdyQt2PFNUgpMK70/JQiQAAAAABMSycAA8XPQAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxc+AAAAAAAAAAAKhsJiVjAbRftl5APiubQDhMdyQt2PFNUgpMK70/JQiQAAAAABMSycAA8XPQAAAAEAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAADxc+AAAAAQAAAAAKhsJiVjAbRftl5APiubQDhMdyQt2PFNUgpMK70/JQiQAAAAFCVEMAAAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAAAAAAAB//////////wAAAAEAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:10:51 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:10:51 GMT
+      Latest-Ledger:
+      - '988990'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2386'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "account_id": "[source_address]",
+          "sequence": "3030756557324297",
+          "subentry_count": 0,
+          "last_modified_ledger": 988989,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9493.8999100",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "[source_address]"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:10:51 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:10:51 GMT
+      Latest-Ledger:
+      - '988990'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2763'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4",
+          "account_id": "GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4",
+          "sequence": "4247675411103745",
+          "subentry_count": 1,
+          "last_modified_ledger": 988990,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "0.0000000",
+              "limit": "922337203685.4775807",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "last_modified_ledger": 988990,
+              "is_authorized": true,
+              "asset_type": "credit_alphanum4",
+              "asset_code": "BTC",
+              "asset_issuer": "[source_address]"
+            },
+            {
+              "balance": "1.9999900",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:10:52 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAAKAAAAAAAAAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa%2FVa29KATZaAAAAAEAAAAACobCYlYwG0X7ZeQD4rm0A4THckLdjxTVIKTCu9PyUIkAAAABQlRDAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa%2FVa29KATZaAAAAABZaC8AAAAAAAAAAAEoBNloAAAAQFyXMzGxmuPvQDOOJbOzWg96ooJNnuW6DAiBxVUhB9yG0YGScJ1DMJJgGwvxqrPWGcl5vJXiigzdbddxzfvS4gM%3D
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:10:56 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1351'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/7da53ca52411111ab67285a1b60dcf704d0eb501ee39987655b9dcfc3f0b4185"
+            }
+          },
+          "hash": "7da53ca52411111ab67285a1b60dcf704d0eb501ee39987655b9dcfc3f0b4185",
+          "ledger": 988991,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAAKAAAAAAAAAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAAEAAAAACobCYlYwG0X7ZeQD4rm0A4THckLdjxTVIKTCu9PyUIkAAAABQlRDAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAABZaC8AAAAAAAAAAAEoBNloAAAAQFyXMzGxmuPvQDOOJbOzWg96ooJNnuW6DAiBxVUhB9yG0YGScJ1DMJJgGwvxqrPWGcl5vJXiigzdbddxzfvS4gM=",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XPwAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAWGs4o2AAKxHUAAAAJAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XPwAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAWGs4o2AAKxHUAAAAKAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAgAAAAMADxc+AAAAAQAAAAAKhsJiVjAbRftl5APiubQDhMdyQt2PFNUgpMK70/JQiQAAAAFCVEMAAAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAAAAAAAB//////////wAAAAEAAAAAAAAAAAAAAAEADxc/AAAAAQAAAAAKhsJiVjAbRftl5APiubQDhMdyQt2PFNUgpMK70/JQiQAAAAFCVEMAAAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAAFloLwB//////////wAAAAEAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:10:56 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:10:56 GMT
+      Latest-Ledger:
+      - '988991'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2765'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4",
+          "account_id": "GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4",
+          "sequence": "4247675411103745",
+          "subentry_count": 1,
+          "last_modified_ledger": 988990,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "150.0000000",
+              "limit": "922337203685.4775807",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "last_modified_ledger": 988991,
+              "is_authorized": true,
+              "asset_type": "credit_alphanum4",
+              "asset_code": "BTC",
+              "asset_issuer": "[source_address]"
+            },
+            {
+              "balance": "1.9999900",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GAFINQTCKYYBWRP3MXSAHYVZWQBYJR3SILOY6FGVECSMFO6T6JIITYV4"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:10:56 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_send_payment/memo/accepts_the_memo_attribute.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_send_payment/memo/accepts_the_memo_attribute.yml
@@ -1,0 +1,725 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:13 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2496'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "accounts": {
+              "href": "https://horizon-testnet.stellar.org/accounts{?signer,asset,cursor,limit,order}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "offer": {
+              "href": "https://horizon-testnet.stellar.org/offers/{offer_id}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/offers{?selling,buying,seller,cursor,limit,order}",
+              "templated": true
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "strict_receive_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-receive{?source_assets,source_account,destination_account,destination_asset_type,destination_asset_issuer,destination_asset_code,destination_amount}",
+              "templated": true
+            },
+            "strict_send_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-send{?destination_account,destination_assets,source_asset_type,source_asset_issuer,source_asset_code,source_amount}",
+              "templated": true
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "1.0.1-2c2d8fb0c3ae0516dcbbb39f189ca00731c9c8c3",
+          "core_version": "stellar-core 12.4.0 (c0136139802ac1a1ac8899424e7888fa9366414e)",
+          "ingest_latest_ledger": 988994,
+          "history_latest_ledger": 988994,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 988994,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "current_protocol_version": 12,
+          "core_supported_protocol_version": 12
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:13 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:13 GMT
+      Latest-Ledger:
+      - '988994'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2386'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "account_id": "[source_address]",
+          "sequence": "3030756557324300",
+          "subentry_count": 0,
+          "last_modified_ledger": 988994,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9491.8998800",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "[source_address]"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:13 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAANAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAZ1HelnaCw%2BFTax26Q6B3gIEzQialf8alQ2DbX2vlQ8kAAAAAO5rKAAAAAAAAAAABKATZaAAAAECy22wirSN0CcoHukiwBlQacCQ0bT%2BrEn1LYKP%2Bz0dX0u9qD13sO2fCsJukY%2FFbGGoEbv1rNGKPCbLounMoISkF
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:17 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1307'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/0debf55fcd20cf0364c253d78c330019970e96f2612e6db1e3311a9bb7928eed"
+            }
+          },
+          "hash": "0debf55fcd20cf0364c253d78c330019970e96f2612e6db1e3311a9bb7928eed",
+          "ledger": 988995,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAANAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAZ1HelnaCw+FTax26Q6B3gIEzQialf8alQ2DbX2vlQ8kAAAAAO5rKAAAAAAAAAAABKATZaAAAAECy22wirSN0CcoHukiwBlQacCQ0bT+rEn1LYKP+z0dX0u9qD13sO2fCsJukY/FbGGoEbv1rNGKPCbLounMoISkF",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XQwAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAWGZz6rAAKxHUAAAAMAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XQwAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAWGZz6rAAKxHUAAAANAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMADxdDAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABYZnPqsAArEdQAAAA0AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdDAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABXeAjCsAArEdQAAAA0AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAADxdDAAAAAAAAAABnUd6WdoLD4VNrHbpDoHeAgTNCJqV/xqVDYNtfa+VDyQAAAAA7msoAAA8XQwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:17 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:17 GMT
+      Latest-Ledger:
+      - '988995'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2386'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "account_id": "[source_address]",
+          "sequence": "3030756557324301",
+          "subentry_count": 0,
+          "last_modified_ledger": 988995,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9391.8998700",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "[source_address]"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:17 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAAOAAAAAAAAAAEAAAAGREVTVUtBAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa%2FVa29KATZaAAAAAEAAAAAZ1HelnaCw%2BFTax26Q6B3gIEzQialf8alQ2DbX2vlQ8kAAAAAAAAAAFloLwAAAAAAAAAAASgE2WgAAABAQeetxwOAObvCa4luUczwdoRI8NS%2F9gO4lIMKt%2BKaHhScmxUET9%2Fy6Apk86pH5ru4a6F1TgeC848Gg6TXtB2BCg%3D%3D
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:22 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1507'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/e2df2a060378dd6f69e7dc43d613e7a3af037f3554a2260ce2ddf451e4a04888"
+            }
+          },
+          "hash": "e2df2a060378dd6f69e7dc43d613e7a3af037f3554a2260ce2ddf451e4a04888",
+          "ledger": 988996,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAAOAAAAAAAAAAEAAAAGREVTVUtBAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAAEAAAAAZ1HelnaCw+FTax26Q6B3gIEzQialf8alQ2DbX2vlQ8kAAAAAAAAAAFloLwAAAAAAAAAAASgE2WgAAABAQeetxwOAObvCa4luUczwdoRI8NS/9gO4lIMKt+KaHhScmxUET9/y6Apk86pH5ru4a6F1TgeC848Gg6TXtB2BCg==",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XRAAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAV3gIwSAAKxHUAAAANAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XRAAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAV3gIwSAAKxHUAAAAOAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMADxdDAAAAAAAAAABnUd6WdoLD4VNrHbpDoHeAgTNCJqV/xqVDYNtfa+VDyQAAAAA7msoAAA8XQwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdEAAAAAAAAAABnUd6WdoLD4VNrHbpDoHeAgTNCJqV/xqVDYNtfa+VDyQAAAACVAvkAAA8XQwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMADxdEAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABXeAjBIAArEdQAAAA4AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdEAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABWEmgFIAArEdQAAAA4AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:22 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBTVDXUWO2BMHYKTNMO3UQ5AO6AICM2CE2SX7RVFINQNWX3L4VB4SI6K
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:22 GMT
+      Latest-Ledger:
+      - '988996'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2385'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBTVDXUWO2BMHYKTNMO3UQ5AO6AICM2CE2SX7RVFINQNWX3L4VB4SI6K"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBTVDXUWO2BMHYKTNMO3UQ5AO6AICM2CE2SX7RVFINQNWX3L4VB4SI6K/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBTVDXUWO2BMHYKTNMO3UQ5AO6AICM2CE2SX7RVFINQNWX3L4VB4SI6K/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBTVDXUWO2BMHYKTNMO3UQ5AO6AICM2CE2SX7RVFINQNWX3L4VB4SI6K/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBTVDXUWO2BMHYKTNMO3UQ5AO6AICM2CE2SX7RVFINQNWX3L4VB4SI6K/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBTVDXUWO2BMHYKTNMO3UQ5AO6AICM2CE2SX7RVFINQNWX3L4VB4SI6K/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBTVDXUWO2BMHYKTNMO3UQ5AO6AICM2CE2SX7RVFINQNWX3L4VB4SI6K/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBTVDXUWO2BMHYKTNMO3UQ5AO6AICM2CE2SX7RVFINQNWX3L4VB4SI6K/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBTVDXUWO2BMHYKTNMO3UQ5AO6AICM2CE2SX7RVFINQNWX3L4VB4SI6K",
+          "account_id": "GBTVDXUWO2BMHYKTNMO3UQ5AO6AICM2CE2SX7RVFINQNWX3L4VB4SI6K",
+          "sequence": "4247701180907520",
+          "subentry_count": 0,
+          "last_modified_ledger": 988996,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "250.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GBTVDXUWO2BMHYKTNMO3UQ5AO6AICM2CE2SX7RVFINQNWX3L4VB4SI6K",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GBTVDXUWO2BMHYKTNMO3UQ5AO6AICM2CE2SX7RVFINQNWX3L4VB4SI6K"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:22 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBTVDXUWO2BMHYKTNMO3UQ5AO6AICM2CE2SX7RVFINQNWX3L4VB4SI6K/transactions?order=desc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:22 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBTVDXUWO2BMHYKTNMO3UQ5AO6AICM2CE2SX7RVFINQNWX3L4VB4SI6K/transactions?cursor=\u0026limit=10\u0026order=desc"
+            },
+            "next": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBTVDXUWO2BMHYKTNMO3UQ5AO6AICM2CE2SX7RVFINQNWX3L4VB4SI6K/transactions?cursor=4247701180928000\u0026limit=10\u0026order=desc"
+            },
+            "prev": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBTVDXUWO2BMHYKTNMO3UQ5AO6AICM2CE2SX7RVFINQNWX3L4VB4SI6K/transactions?cursor=4247705475883008\u0026limit=10\u0026order=asc"
+            }
+          },
+          "_embedded": {
+            "records": [
+              {
+                "memo": "DESUKA",
+                "_links": {
+                  "self": {
+                    "href": "https://horizon-testnet.stellar.org/transactions/e2df2a060378dd6f69e7dc43d613e7a3af037f3554a2260ce2ddf451e4a04888"
+                  },
+                  "account": {
+                    "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+                  },
+                  "ledger": {
+                    "href": "https://horizon-testnet.stellar.org/ledgers/988996"
+                  },
+                  "operations": {
+                    "href": "https://horizon-testnet.stellar.org/transactions/e2df2a060378dd6f69e7dc43d613e7a3af037f3554a2260ce2ddf451e4a04888/operations{?cursor,limit,order}",
+                    "templated": true
+                  },
+                  "effects": {
+                    "href": "https://horizon-testnet.stellar.org/transactions/e2df2a060378dd6f69e7dc43d613e7a3af037f3554a2260ce2ddf451e4a04888/effects{?cursor,limit,order}",
+                    "templated": true
+                  },
+                  "precedes": {
+                    "href": "https://horizon-testnet.stellar.org/transactions?order=asc\u0026cursor=4247705475883008"
+                  },
+                  "succeeds": {
+                    "href": "https://horizon-testnet.stellar.org/transactions?order=desc\u0026cursor=4247705475883008"
+                  }
+                },
+                "id": "e2df2a060378dd6f69e7dc43d613e7a3af037f3554a2260ce2ddf451e4a04888",
+                "paging_token": "4247705475883008",
+                "successful": true,
+                "hash": "e2df2a060378dd6f69e7dc43d613e7a3af037f3554a2260ce2ddf451e4a04888",
+                "ledger": 988996,
+                "created_at": "2020-03-31T19:11:20Z",
+                "source_account": "[source_address]",
+                "source_account_sequence": "3030756557324302",
+                "fee_charged": 100,
+                "max_fee": 100,
+                "operation_count": 1,
+                "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAAOAAAAAAAAAAEAAAAGREVTVUtBAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAAEAAAAAZ1HelnaCw+FTax26Q6B3gIEzQialf8alQ2DbX2vlQ8kAAAAAAAAAAFloLwAAAAAAAAAAASgE2WgAAABAQeetxwOAObvCa4luUczwdoRI8NS/9gO4lIMKt+KaHhScmxUET9/y6Apk86pH5ru4a6F1TgeC848Gg6TXtB2BCg==",
+                "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+                "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XRAAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAV3gIwSAAKxHUAAAANAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XRAAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAV3gIwSAAKxHUAAAAOAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMADxdDAAAAAAAAAABnUd6WdoLD4VNrHbpDoHeAgTNCJqV/xqVDYNtfa+VDyQAAAAA7msoAAA8XQwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdEAAAAAAAAAABnUd6WdoLD4VNrHbpDoHeAgTNCJqV/xqVDYNtfa+VDyQAAAACVAvkAAA8XQwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMADxdEAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABXeAjBIAArEdQAAAA4AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdEAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABWEmgFIAArEdQAAAA4AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+                "fee_meta_xdr": "AAAAAgAAAAMADxdDAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABXeAjCsAArEdQAAAA0AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdEAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABXeAjBIAArEdQAAAA0AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+                "memo_type": "text",
+                "signatures": [
+                  "QeetxwOAObvCa4luUczwdoRI8NS/9gO4lIMKt+KaHhScmxUET9/y6Apk86pH5ru4a6F1TgeC848Gg6TXtB2BCg=="
+                ]
+              },
+              {
+                "_links": {
+                  "self": {
+                    "href": "https://horizon-testnet.stellar.org/transactions/0debf55fcd20cf0364c253d78c330019970e96f2612e6db1e3311a9bb7928eed"
+                  },
+                  "account": {
+                    "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+                  },
+                  "ledger": {
+                    "href": "https://horizon-testnet.stellar.org/ledgers/988995"
+                  },
+                  "operations": {
+                    "href": "https://horizon-testnet.stellar.org/transactions/0debf55fcd20cf0364c253d78c330019970e96f2612e6db1e3311a9bb7928eed/operations{?cursor,limit,order}",
+                    "templated": true
+                  },
+                  "effects": {
+                    "href": "https://horizon-testnet.stellar.org/transactions/0debf55fcd20cf0364c253d78c330019970e96f2612e6db1e3311a9bb7928eed/effects{?cursor,limit,order}",
+                    "templated": true
+                  },
+                  "precedes": {
+                    "href": "https://horizon-testnet.stellar.org/transactions?order=asc\u0026cursor=4247701180928000"
+                  },
+                  "succeeds": {
+                    "href": "https://horizon-testnet.stellar.org/transactions?order=desc\u0026cursor=4247701180928000"
+                  }
+                },
+                "id": "0debf55fcd20cf0364c253d78c330019970e96f2612e6db1e3311a9bb7928eed",
+                "paging_token": "4247701180928000",
+                "successful": true,
+                "hash": "0debf55fcd20cf0364c253d78c330019970e96f2612e6db1e3311a9bb7928eed",
+                "ledger": 988995,
+                "created_at": "2020-03-31T19:11:15Z",
+                "source_account": "[source_address]",
+                "source_account_sequence": "3030756557324301",
+                "fee_charged": 100,
+                "max_fee": 100,
+                "operation_count": 1,
+                "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAANAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAZ1HelnaCw+FTax26Q6B3gIEzQialf8alQ2DbX2vlQ8kAAAAAO5rKAAAAAAAAAAABKATZaAAAAECy22wirSN0CcoHukiwBlQacCQ0bT+rEn1LYKP+z0dX0u9qD13sO2fCsJukY/FbGGoEbv1rNGKPCbLounMoISkF",
+                "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+                "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XQwAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAWGZz6rAAKxHUAAAAMAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XQwAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAWGZz6rAAKxHUAAAANAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMADxdDAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABYZnPqsAArEdQAAAA0AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdDAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABXeAjCsAArEdQAAAA0AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAADxdDAAAAAAAAAABnUd6WdoLD4VNrHbpDoHeAgTNCJqV/xqVDYNtfa+VDyQAAAAA7msoAAA8XQwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+                "fee_meta_xdr": "AAAAAgAAAAMADxdCAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABYZnPsQAArEdQAAAAwAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdDAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABYZnPqsAArEdQAAAAwAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+                "memo_type": "none",
+                "signatures": [
+                  "sttsIq0jdAnKB7pIsAZUGnAkNG0/qxJ9S2Cj/s9HV9Lvag9d7DtnwrCbpGPxWxhqBG79azRijwmy6LpzKCEpBQ=="
+                ]
+              }
+            ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:22 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_send_payment/native_asset/sends_a_native_payment_to_the_account.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_send_payment/native_asset/sends_a_native_payment_to_the_account.yml
@@ -1,0 +1,686 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:10:33 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2496'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "accounts": {
+              "href": "https://horizon-testnet.stellar.org/accounts{?signer,asset,cursor,limit,order}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "offer": {
+              "href": "https://horizon-testnet.stellar.org/offers/{offer_id}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/offers{?selling,buying,seller,cursor,limit,order}",
+              "templated": true
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "strict_receive_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-receive{?source_assets,source_account,destination_account,destination_asset_type,destination_asset_issuer,destination_asset_code,destination_amount}",
+              "templated": true
+            },
+            "strict_send_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-send{?destination_account,destination_assets,source_asset_type,source_asset_issuer,source_asset_code,source_amount}",
+              "templated": true
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "1.0.1-2c2d8fb0c3ae0516dcbbb39f189ca00731c9c8c3",
+          "core_version": "stellar-core 12.4.0 (c0136139802ac1a1ac8899424e7888fa9366414e)",
+          "ingest_latest_ledger": 988986,
+          "history_latest_ledger": 988986,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 988986,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "current_protocol_version": 12,
+          "core_supported_protocol_version": 12
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:10:33 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:10:33 GMT
+      Latest-Ledger:
+      - '988986'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2386'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "account_id": "[source_address]",
+          "sequence": "3030756557324294",
+          "subentry_count": 0,
+          "last_modified_ledger": 705785,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9745.8999400",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "[source_address]"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:10:34 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAAHAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAgsNtqPjFSFasqgk9%2BeT7VbsZBXuEHlIZO5q1OjxQZKMAAAAAO5rKAAAAAAAAAAABKATZaAAAAEBHu0qHwW1%2B5HJ3bhZv%2FqZQ%2B0%2FTcTsj1DBL4N5sSyQzAXr0j8UgogcbQ4cqwY%2F4bBNLYYlLZSQv6aOAqfmDjpkL
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:10:36 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1307'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/5c9385a10275ec6830fd46047483403f3574e1696158ff86a98bb1fbabe9ae7a"
+            }
+          },
+          "hash": "5c9385a10275ec6830fd46047483403f3574e1696158ff86a98bb1fbabe9ae7a",
+          "ledger": 988987,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAAHAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAgsNtqPjFSFasqgk9+eT7VbsZBXuEHlIZO5q1OjxQZKMAAAAAO5rKAAAAAAAAAAABKATZaAAAAEBHu0qHwW1+5HJ3bhZv/qZQ+0/TcTsj1DBL4N5sSyQzAXr0j8UgogcbQ4cqwY/4bBNLYYlLZSQv6aOAqfmDjpkL",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XOwAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAWsQJQBAAKxHUAAAAGAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XOwAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAWsQJQBAAKxHUAAAAHAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMADxc7AAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABaxAlAEAArEdQAAAAcAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxc7AAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABZ1Z4YEAArEdQAAAAcAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAADxc7AAAAAAAAAACCw22o+MVIVqyqCT355PtVuxkFe4QeUhk7mrU6PFBkowAAAAA7msoAAA8XOwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:10:36 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:10:36 GMT
+      Latest-Ledger:
+      - '988987'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2386'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "account_id": "[source_address]",
+          "sequence": "3030756557324295",
+          "subentry_count": 0,
+          "last_modified_ledger": 988987,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9645.8999300",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "[source_address]"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:10:36 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:10:36 GMT
+      Latest-Ledger:
+      - '988987'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2385'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN",
+          "account_id": "GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN",
+          "sequence": "4247666821169152",
+          "subentry_count": 0,
+          "last_modified_ledger": 988987,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "100.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:10:37 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAAIAAAAAAAAAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa%2FVa29KATZaAAAAAEAAAAAgsNtqPjFSFasqgk9%2BeT7VbsZBXuEHlIZO5q1OjxQZKMAAAAAAAAAAFloLwAAAAAAAAAAASgE2WgAAABAoN6%2FmzkAAUsNAR6O%2BvM8zJ7idBAl%2FfmglXYc3PGHI5L7LHS1LfSH35QqSDcUqeKyjWRuQmUQXhYQTTCwvNwGAg%3D%3D
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:10:41 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1491'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/4a30eb7de1571ddafbd7a29d6ce85add4e8e8bd314c7efa279980d1d8da07466"
+            }
+          },
+          "hash": "4a30eb7de1571ddafbd7a29d6ce85add4e8e8bd314c7efa279980d1d8da07466",
+          "ledger": 988988,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAAIAAAAAAAAAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAAEAAAAAgsNtqPjFSFasqgk9+eT7VbsZBXuEHlIZO5q1OjxQZKMAAAAAAAAAAFloLwAAAAAAAAAAASgE2WgAAABAoN6/mzkAAUsNAR6O+vM8zJ7idBAl/fmglXYc3PGHI5L7LHS1LfSH35QqSDcUqeKyjWRuQmUQXhYQTTCwvNwGAg==",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XPAAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAWdWeFoAAKxHUAAAAHAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XPAAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAWdWeFoAAKxHUAAAAIAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMADxc7AAAAAAAAAACCw22o+MVIVqyqCT355PtVuxkFe4QeUhk7mrU6PFBkowAAAAA7msoAAA8XOwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxc8AAAAAAAAAACCw22o+MVIVqyqCT355PtVuxkFe4QeUhk7mrU6PFBkowAAAACVAvkAAA8XOwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMADxc8AAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABZ1Z4WgAArEdQAAAAgAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxc8AAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABYb/1agAArEdQAAAAgAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:10:41 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:10:41 GMT
+      Latest-Ledger:
+      - '988988'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2385'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN",
+          "account_id": "GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN",
+          "sequence": "4247666821169152",
+          "subentry_count": 0,
+          "last_modified_ledger": 988988,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "250.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GCBMG3NI7DCUQVVMVIET36PE7NK3WGIFPOCB4UQZHONLKOR4KBSKHUNN"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:10:41 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_send_payment/using_a_payment_channel/sends_a_payment_account_through_a_channel_account.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_send_payment/using_a_payment_channel/sends_a_payment_account_through_a_channel_account.yml
@@ -1,0 +1,871 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:23 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2496'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "accounts": {
+              "href": "https://horizon-testnet.stellar.org/accounts{?signer,asset,cursor,limit,order}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "offer": {
+              "href": "https://horizon-testnet.stellar.org/offers/{offer_id}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/offers{?selling,buying,seller,cursor,limit,order}",
+              "templated": true
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "strict_receive_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-receive{?source_assets,source_account,destination_account,destination_asset_type,destination_asset_issuer,destination_asset_code,destination_amount}",
+              "templated": true
+            },
+            "strict_send_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-send{?destination_account,destination_assets,source_asset_type,source_asset_issuer,source_asset_code,source_amount}",
+              "templated": true
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "1.0.1-2c2d8fb0c3ae0516dcbbb39f189ca00731c9c8c3",
+          "core_version": "stellar-core 12.4.0 (c0136139802ac1a1ac8899424e7888fa9366414e)",
+          "ingest_latest_ledger": 988996,
+          "history_latest_ledger": 988996,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 988996,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "current_protocol_version": 12,
+          "core_supported_protocol_version": 12
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:23 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:23 GMT
+      Latest-Ledger:
+      - '988996'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2386'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "account_id": "[source_address]",
+          "sequence": "3030756557324302",
+          "subentry_count": 0,
+          "last_modified_ledger": 988996,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9241.8998600",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "[source_address]"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:23 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAAPAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAJ%2F3UgDCrvGh5S%2BvZs9AnfJdIKc6xKHMBgo6AmDBgwFwAAAAAAJiWgAAAAAAAAAABKATZaAAAAECwT3CQ70UTDG0OG40gCzkcvRGHtSTLp5XwhmXJRt%2F5qKR1obT7l8I2974dnrCC4ZiWVqzHZIRZeDdyz1t%2BSyAG
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:27 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1307'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/611ebfe89845ad57618799a03511c2074877b7f3e8df26ccfdd845ca72995bf6"
+            }
+          },
+          "hash": "611ebfe89845ad57618799a03511c2074877b7f3e8df26ccfdd845ca72995bf6",
+          "ledger": 988997,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAAPAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAJ/3UgDCrvGh5S+vZs9AnfJdIKc6xKHMBgo6AmDBgwFwAAAAAAJiWgAAAAAAAAAABKATZaAAAAECwT3CQ70UTDG0OG40gCzkcvRGHtSTLp5XwhmXJRt/5qKR1obT7l8I2974dnrCC4ZiWVqzHZIRZeDdyz1t+SyAG",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XRQAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAVhJoA5AAKxHUAAAAOAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XRQAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAVhJoA5AAKxHUAAAAPAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMADxdFAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABWEmgDkAArEdQAAAA8AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdFAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABWEAWpkAArEdQAAAA8AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAADxdFAAAAAAAAAAAn/dSAMKu8aHlL69mz0Cd8l0gpzrEocwGCjoCYMGDAXAAAAAAAmJaAAA8XRQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:27 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[channel_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:27 GMT
+      Latest-Ledger:
+      - '988997'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2386'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[channel_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[channel_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[channel_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[channel_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[channel_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[channel_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[channel_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[channel_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[channel_address]",
+          "account_id": "[channel_address]",
+          "sequence": "3031280543334401",
+          "subentry_count": 0,
+          "last_modified_ledger": 705778,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9999.9999900",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "[channel_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "[channel_address]"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:27 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:28 GMT
+      Latest-Ledger:
+      - '988997'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2383'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O",
+          "account_id": "GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O",
+          "sequence": "4247709770842112",
+          "subentry_count": 0,
+          "last_modified_ledger": 988997,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "1.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:28 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAFdYqivjRY8wI3xww%2FBQyzDCaEkwqgH3EovHSX%2BAiSBPAAAAZAAKxO8AAAACAAAAAAAAAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa%2FVa29KATZaAAAAAEAAAAAJ%2F3UgDCrvGh5S%2BvZs9AnfJdIKc6xKHMBgo6AmDBgwFwAAAAAAAAAAABT7GAAAAAAAAAAAoCJIE8AAABA%2BnI10u3iTd2q61e3BUqfBRnebDHg0fzGRmn2KPT64Lhhx3Q%2FJcYL9A7oXM7Dto%2BRpPQog98i6txIgr2gcZH5BCgE2WgAAABAYZC6K1rwH%2BfFtX91eYBuxjcMkKzfHpS5cTURynZMbHf1ULhAFk%2F0%2BdeLj3IJszP4wZdgxoyMiebVvhOPk6e1DA%3D%3D
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:32 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1587'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/32374e3e1635efe8579cf3700c8f71602109b41e227cd280f7cd7b02232ee644"
+            }
+          },
+          "hash": "32374e3e1635efe8579cf3700c8f71602109b41e227cd280f7cd7b02232ee644",
+          "ledger": 988998,
+          "envelope_xdr": "AAAAAFdYqivjRY8wI3xww/BQyzDCaEkwqgH3EovHSX+AiSBPAAAAZAAKxO8AAAACAAAAAAAAAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAAEAAAAAJ/3UgDCrvGh5S+vZs9AnfJdIKc6xKHMBgo6AmDBgwFwAAAAAAAAAAABT7GAAAAAAAAAAAoCJIE8AAABA+nI10u3iTd2q61e3BUqfBRnebDHg0fzGRmn2KPT64Lhhx3Q/JcYL9A7oXM7Dto+RpPQog98i6txIgr2gcZH5BCgE2WgAAABAYZC6K1rwH+fFtX91eYBuxjcMkKzfHpS5cTURynZMbHf1ULhAFk/0+deLj3IJszP4wZdgxoyMiebVvhOPk6e1DA==",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XRgAAAAAAAAAAV1iqK+NFjzAjfHDD8FDLMMJoSTCqAfcSi8dJf4CJIE8AAAAXSHbnOAAKxO8AAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XRgAAAAAAAAAAV1iqK+NFjzAjfHDD8FDLMMJoSTCqAfcSi8dJf4CJIE8AAAAXSHbnOAAKxO8AAAACAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMADxdFAAAAAAAAAAAn/dSAMKu8aHlL69mz0Cd8l0gpzrEocwGCjoCYMGDAXAAAAAAAmJaAAA8XRQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdGAAAAAAAAAAAn/dSAMKu8aHlL69mz0Cd8l0gpzrEocwGCjoCYMGDAXAAAAAAA7ILgAA8XRQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMADxdFAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABWEAWpkAArEdQAAAA8AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdGAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABWDrX4EAArEdQAAAA8AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:32 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/transactions/32374e3e1635efe8579cf3700c8f71602109b41e227cd280f7cd7b02232ee644
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:32 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '3385'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/transactions/32374e3e1635efe8579cf3700c8f71602109b41e227cd280f7cd7b02232ee644"
+            },
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[channel_address]"
+            },
+            "ledger": {
+              "href": "https://horizon-testnet.stellar.org/ledgers/988998"
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/transactions/32374e3e1635efe8579cf3700c8f71602109b41e227cd280f7cd7b02232ee644/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/transactions/32374e3e1635efe8579cf3700c8f71602109b41e227cd280f7cd7b02232ee644/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "precedes": {
+              "href": "https://horizon-testnet.stellar.org/transactions?order=asc\u0026cursor=4247714065825792"
+            },
+            "succeeds": {
+              "href": "https://horizon-testnet.stellar.org/transactions?order=desc\u0026cursor=4247714065825792"
+            }
+          },
+          "id": "32374e3e1635efe8579cf3700c8f71602109b41e227cd280f7cd7b02232ee644",
+          "paging_token": "4247714065825792",
+          "successful": true,
+          "hash": "32374e3e1635efe8579cf3700c8f71602109b41e227cd280f7cd7b02232ee644",
+          "ledger": 988998,
+          "created_at": "2020-03-31T19:11:30Z",
+          "source_account": "[channel_address]",
+          "source_account_sequence": "3031280543334402",
+          "fee_charged": 100,
+          "max_fee": 100,
+          "operation_count": 1,
+          "envelope_xdr": "AAAAAFdYqivjRY8wI3xww/BQyzDCaEkwqgH3EovHSX+AiSBPAAAAZAAKxO8AAAACAAAAAAAAAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAAEAAAAAJ/3UgDCrvGh5S+vZs9AnfJdIKc6xKHMBgo6AmDBgwFwAAAAAAAAAAABT7GAAAAAAAAAAAoCJIE8AAABA+nI10u3iTd2q61e3BUqfBRnebDHg0fzGRmn2KPT64Lhhx3Q/JcYL9A7oXM7Dto+RpPQog98i6txIgr2gcZH5BCgE2WgAAABAYZC6K1rwH+fFtX91eYBuxjcMkKzfHpS5cTURynZMbHf1ULhAFk/0+deLj3IJszP4wZdgxoyMiebVvhOPk6e1DA==",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XRgAAAAAAAAAAV1iqK+NFjzAjfHDD8FDLMMJoSTCqAfcSi8dJf4CJIE8AAAAXSHbnOAAKxO8AAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XRgAAAAAAAAAAV1iqK+NFjzAjfHDD8FDLMMJoSTCqAfcSi8dJf4CJIE8AAAAXSHbnOAAKxO8AAAACAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMADxdFAAAAAAAAAAAn/dSAMKu8aHlL69mz0Cd8l0gpzrEocwGCjoCYMGDAXAAAAAAAmJaAAA8XRQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdGAAAAAAAAAAAn/dSAMKu8aHlL69mz0Cd8l0gpzrEocwGCjoCYMGDAXAAAAAAA7ILgAA8XRQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMADxdFAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABWEAWpkAArEdQAAAA8AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdGAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABWDrX4EAArEdQAAAA8AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+          "fee_meta_xdr": "AAAAAgAAAAMACsTyAAAAAAAAAABXWKor40WPMCN8cMPwUMswwmhJMKoB9xKLx0l/gIkgTwAAABdIduecAArE7wAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdGAAAAAAAAAABXWKor40WPMCN8cMPwUMswwmhJMKoB9xKLx0l/gIkgTwAAABdIduc4AArE7wAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+          "memo_type": "none",
+          "signatures": [
+            "+nI10u3iTd2q61e3BUqfBRnebDHg0fzGRmn2KPT64Lhhx3Q/JcYL9A7oXM7Dto+RpPQog98i6txIgr2gcZH5BA==",
+            "YZC6K1rwH+fFtX91eYBuxjcMkKzfHpS5cTURynZMbHf1ULhAFk/0+deLj3IJszP4wZdgxoyMiebVvhOPk6e1DA=="
+          ]
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:32 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/transactions/32374e3e1635efe8579cf3700c8f71602109b41e227cd280f7cd7b02232ee644/operations
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:32 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2057'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/transactions/32374e3e1635efe8579cf3700c8f71602109b41e227cd280f7cd7b02232ee644/operations?cursor=\u0026limit=10\u0026order=asc"
+            },
+            "next": {
+              "href": "https://horizon-testnet.stellar.org/transactions/32374e3e1635efe8579cf3700c8f71602109b41e227cd280f7cd7b02232ee644/operations?cursor=4247714065825793\u0026limit=10\u0026order=asc"
+            },
+            "prev": {
+              "href": "https://horizon-testnet.stellar.org/transactions/32374e3e1635efe8579cf3700c8f71602109b41e227cd280f7cd7b02232ee644/operations?cursor=4247714065825793\u0026limit=10\u0026order=desc"
+            }
+          },
+          "_embedded": {
+            "records": [
+              {
+                "_links": {
+                  "self": {
+                    "href": "https://horizon-testnet.stellar.org/operations/4247714065825793"
+                  },
+                  "transaction": {
+                    "href": "https://horizon-testnet.stellar.org/transactions/32374e3e1635efe8579cf3700c8f71602109b41e227cd280f7cd7b02232ee644"
+                  },
+                  "effects": {
+                    "href": "https://horizon-testnet.stellar.org/operations/4247714065825793/effects"
+                  },
+                  "succeeds": {
+                    "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=4247714065825793"
+                  },
+                  "precedes": {
+                    "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=4247714065825793"
+                  }
+                },
+                "id": "4247714065825793",
+                "paging_token": "4247714065825793",
+                "transaction_successful": true,
+                "source_account": "[source_address]",
+                "type": "payment",
+                "type_i": 1,
+                "created_at": "2020-03-31T19:11:30Z",
+                "transaction_hash": "32374e3e1635efe8579cf3700c8f71602109b41e227cd280f7cd7b02232ee644",
+                "asset_type": "native",
+                "from": "[source_address]",
+                "to": "GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O",
+                "amount": "0.5500000"
+              }
+            ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:32 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:33 GMT
+      Latest-Ledger:
+      - '988998'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2383'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O",
+          "account_id": "GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O",
+          "sequence": "4247709770842112",
+          "subentry_count": 0,
+          "last_modified_ledger": 988998,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "1.5500000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GAT73VEAGCV3Y2DZJPV5TM6QE56JOSBJZ2YSQ4YBQKHIBGBQMDAFZJ2O"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:33 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_send_payment/using_a_payment_channel/sends_a_payment_when_the_channel_is_the_same_as_from_.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_send_payment/using_a_payment_channel/sends_a_payment_when_the_channel_is_the_same_as_from_.yml
@@ -1,0 +1,756 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:33 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2496'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "accounts": {
+              "href": "https://horizon-testnet.stellar.org/accounts{?signer,asset,cursor,limit,order}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "offer": {
+              "href": "https://horizon-testnet.stellar.org/offers/{offer_id}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/offers{?selling,buying,seller,cursor,limit,order}",
+              "templated": true
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "strict_receive_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-receive{?source_assets,source_account,destination_account,destination_asset_type,destination_asset_issuer,destination_asset_code,destination_amount}",
+              "templated": true
+            },
+            "strict_send_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-send{?destination_account,destination_assets,source_asset_type,source_asset_issuer,source_asset_code,source_amount}",
+              "templated": true
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "1.0.1-2c2d8fb0c3ae0516dcbbb39f189ca00731c9c8c3",
+          "core_version": "stellar-core 12.4.0 (c0136139802ac1a1ac8899424e7888fa9366414e)",
+          "ingest_latest_ledger": 988998,
+          "history_latest_ledger": 988998,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 988998,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "current_protocol_version": 12,
+          "core_supported_protocol_version": 12
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:33 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:34 GMT
+      Latest-Ledger:
+      - '988998'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2386'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "account_id": "[source_address]",
+          "sequence": "3030756557324303",
+          "subentry_count": 0,
+          "last_modified_ledger": 988998,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9240.3498500",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "[source_address]"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:34 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAAQAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA3okaPcOQH8mqU2yHMUOXoehAyVdab%2F2zQxlbdSpWxi4AAAAAAJiWgAAAAAAAAAABKATZaAAAAEAGXIqfdUwDXqKYQ1c5zAVmv%2B%2BQ2wOmD5gmzThnXnNz2g80D5AqwbmlkyOAq8dbBOl62QsVbLIRoKCChaaypvsB
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:37 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1307'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/d9fa86c8974d9583a6ff6a358036b9bd75f5e330a0a80d55e9160c93c97471d4"
+            }
+          },
+          "hash": "d9fa86c8974d9583a6ff6a358036b9bd75f5e330a0a80d55e9160c93c97471d4",
+          "ledger": 988999,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAAQAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA3okaPcOQH8mqU2yHMUOXoehAyVdab/2zQxlbdSpWxi4AAAAAAJiWgAAAAAAAAAABKATZaAAAAEAGXIqfdUwDXqKYQ1c5zAVmv++Q2wOmD5gmzThnXnNz2g80D5AqwbmlkyOAq8dbBOl62QsVbLIRoKCChaaypvsB",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XRwAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAVg619oAAKxHUAAAAPAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XRwAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAVg619oAAKxHUAAAAQAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMADxdHAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABWDrX2gAArEdQAAABAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdHAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABWDFOcgAArEdQAAABAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAADxdHAAAAAAAAAADeiRo9w5AfyapTbIcxQ5eh6EDJV1pv/bNDGVt1KlbGLgAAAAAAmJaAAA8XRwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:37 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/[source_address]
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:37 GMT
+      Latest-Ledger:
+      - '988999'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2386'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "[source_address]",
+          "account_id": "[source_address]",
+          "sequence": "3030756557324304",
+          "subentry_count": 0,
+          "last_modified_ledger": 988999,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9239.3498400",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "[source_address]",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "[source_address]"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:37 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GDPISGR5YOIB7SNKKNWIOMKDS6Q6QQGJK5NG77NTIMMVW5JKK3DC4ZII
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:37 GMT
+      Latest-Ledger:
+      - '988999'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2383'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDPISGR5YOIB7SNKKNWIOMKDS6Q6QQGJK5NG77NTIMMVW5JKK3DC4ZII"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDPISGR5YOIB7SNKKNWIOMKDS6Q6QQGJK5NG77NTIMMVW5JKK3DC4ZII/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDPISGR5YOIB7SNKKNWIOMKDS6Q6QQGJK5NG77NTIMMVW5JKK3DC4ZII/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDPISGR5YOIB7SNKKNWIOMKDS6Q6QQGJK5NG77NTIMMVW5JKK3DC4ZII/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDPISGR5YOIB7SNKKNWIOMKDS6Q6QQGJK5NG77NTIMMVW5JKK3DC4ZII/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDPISGR5YOIB7SNKKNWIOMKDS6Q6QQGJK5NG77NTIMMVW5JKK3DC4ZII/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDPISGR5YOIB7SNKKNWIOMKDS6Q6QQGJK5NG77NTIMMVW5JKK3DC4ZII/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDPISGR5YOIB7SNKKNWIOMKDS6Q6QQGJK5NG77NTIMMVW5JKK3DC4ZII/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GDPISGR5YOIB7SNKKNWIOMKDS6Q6QQGJK5NG77NTIMMVW5JKK3DC4ZII",
+          "account_id": "GDPISGR5YOIB7SNKKNWIOMKDS6Q6QQGJK5NG77NTIMMVW5JKK3DC4ZII",
+          "sequence": "4247718360776704",
+          "subentry_count": 0,
+          "last_modified_ledger": 988999,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "1.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GDPISGR5YOIB7SNKKNWIOMKDS6Q6QQGJK5NG77NTIMMVW5JKK3DC4ZII",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GDPISGR5YOIB7SNKKNWIOMKDS6Q6QQGJK5NG77NTIMMVW5JKK3DC4ZII"
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:38 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAARAAAAAAAAAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa%2FVa29KATZaAAAAAEAAAAA3okaPcOQH8mqU2yHMUOXoehAyVdab%2F2zQxlbdSpWxi4AAAAAAAAAAABT7GAAAAAAAAAAASgE2WgAAABAdr4MtscU8Zuy8Mut1j13dn4QLUPSK42kFJRvIcOiOKTjZfGT%2BgnRoO6KtuwBGGKvP65PF18FgOkRUBtAsp%2FyDg%3D%3D
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:43 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1491'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/6dd25f3b8dcee0b924394fe0ee620d69157e5c5011922c67c651fcad2a9c510c"
+            }
+          },
+          "hash": "6dd25f3b8dcee0b924394fe0ee620d69157e5c5011922c67c651fcad2a9c510c",
+          "ledger": 989000,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAARAAAAAAAAAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAAEAAAAA3okaPcOQH8mqU2yHMUOXoehAyVdab/2zQxlbdSpWxi4AAAAAAAAAAABT7GAAAAAAAAAAASgE2WgAAABAdr4MtscU8Zuy8Mut1j13dn4QLUPSK42kFJRvIcOiOKTjZfGT+gnRoO6KtuwBGGKvP65PF18FgOkRUBtAsp/yDg==",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XSAAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAVgxTmvAAKxHUAAAAQAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XSAAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAVgxTmvAAKxHUAAAARAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMADxdHAAAAAAAAAADeiRo9w5AfyapTbIcxQ5eh6EDJV1pv/bNDGVt1KlbGLgAAAAAAmJaAAA8XRwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdIAAAAAAAAAADeiRo9w5AfyapTbIcxQ5eh6EDJV1pv/bNDGVt1KlbGLgAAAAAA7ILgAA8XRwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMADxdIAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABWDFOa8AArEdQAAABEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdIAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABWCwPpcAArEdQAAABEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:43 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/transactions/6dd25f3b8dcee0b924394fe0ee620d69157e5c5011922c67c651fcad2a9c510c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:43 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '3193'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/transactions/6dd25f3b8dcee0b924394fe0ee620d69157e5c5011922c67c651fcad2a9c510c"
+            },
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/[source_address]"
+            },
+            "ledger": {
+              "href": "https://horizon-testnet.stellar.org/ledgers/989000"
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/transactions/6dd25f3b8dcee0b924394fe0ee620d69157e5c5011922c67c651fcad2a9c510c/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/transactions/6dd25f3b8dcee0b924394fe0ee620d69157e5c5011922c67c651fcad2a9c510c/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "precedes": {
+              "href": "https://horizon-testnet.stellar.org/transactions?order=asc\u0026cursor=4247722655768576"
+            },
+            "succeeds": {
+              "href": "https://horizon-testnet.stellar.org/transactions?order=desc\u0026cursor=4247722655768576"
+            }
+          },
+          "id": "6dd25f3b8dcee0b924394fe0ee620d69157e5c5011922c67c651fcad2a9c510c",
+          "paging_token": "4247722655768576",
+          "successful": true,
+          "hash": "6dd25f3b8dcee0b924394fe0ee620d69157e5c5011922c67c651fcad2a9c510c",
+          "ledger": 989000,
+          "created_at": "2020-03-31T19:11:40Z",
+          "source_account": "[source_address]",
+          "source_account_sequence": "3030756557324305",
+          "fee_charged": 100,
+          "max_fee": 100,
+          "operation_count": 1,
+          "envelope_xdr": "AAAAAJA8Jibp68sQkog4sikMusVOeuhVzZVx9r9Vrb0oBNloAAAAZAAKxHUAAAARAAAAAAAAAAAAAAABAAAAAQAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAAAEAAAAA3okaPcOQH8mqU2yHMUOXoehAyVdab/2zQxlbdSpWxi4AAAAAAAAAAABT7GAAAAAAAAAAASgE2WgAAABAdr4MtscU8Zuy8Mut1j13dn4QLUPSK42kFJRvIcOiOKTjZfGT+gnRoO6KtuwBGGKvP65PF18FgOkRUBtAsp/yDg==",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA8XSAAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAVgxTmvAAKxHUAAAAQAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA8XSAAAAAAAAAAAkDwmJunryxCSiDiyKQy6xU566FXNlXH2v1WtvSgE2WgAAAAVgxTmvAAKxHUAAAARAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMADxdHAAAAAAAAAADeiRo9w5AfyapTbIcxQ5eh6EDJV1pv/bNDGVt1KlbGLgAAAAAAmJaAAA8XRwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdIAAAAAAAAAADeiRo9w5AfyapTbIcxQ5eh6EDJV1pv/bNDGVt1KlbGLgAAAAAA7ILgAA8XRwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMADxdIAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABWDFOa8AArEdQAAABEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdIAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABWCwPpcAArEdQAAABEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+          "fee_meta_xdr": "AAAAAgAAAAMADxdHAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABWDFOcgAArEdQAAABAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADxdIAAAAAAAAAACQPCYm6evLEJKIOLIpDLrFTnroVc2Vcfa/Va29KATZaAAAABWDFOa8AArEdQAAABAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+          "memo_type": "none",
+          "signatures": [
+            "dr4MtscU8Zuy8Mut1j13dn4QLUPSK42kFJRvIcOiOKTjZfGT+gnRoO6KtuwBGGKvP65PF18FgOkRUBtAsp/yDg=="
+          ]
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:43 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/transactions/6dd25f3b8dcee0b924394fe0ee620d69157e5c5011922c67c651fcad2a9c510c/operations
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 31 Mar 2020 19:11:43 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2057'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/transactions/6dd25f3b8dcee0b924394fe0ee620d69157e5c5011922c67c651fcad2a9c510c/operations?cursor=\u0026limit=10\u0026order=asc"
+            },
+            "next": {
+              "href": "https://horizon-testnet.stellar.org/transactions/6dd25f3b8dcee0b924394fe0ee620d69157e5c5011922c67c651fcad2a9c510c/operations?cursor=4247722655768577\u0026limit=10\u0026order=asc"
+            },
+            "prev": {
+              "href": "https://horizon-testnet.stellar.org/transactions/6dd25f3b8dcee0b924394fe0ee620d69157e5c5011922c67c651fcad2a9c510c/operations?cursor=4247722655768577\u0026limit=10\u0026order=desc"
+            }
+          },
+          "_embedded": {
+            "records": [
+              {
+                "_links": {
+                  "self": {
+                    "href": "https://horizon-testnet.stellar.org/operations/4247722655768577"
+                  },
+                  "transaction": {
+                    "href": "https://horizon-testnet.stellar.org/transactions/6dd25f3b8dcee0b924394fe0ee620d69157e5c5011922c67c651fcad2a9c510c"
+                  },
+                  "effects": {
+                    "href": "https://horizon-testnet.stellar.org/operations/4247722655768577/effects"
+                  },
+                  "succeeds": {
+                    "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=4247722655768577"
+                  },
+                  "precedes": {
+                    "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=4247722655768577"
+                  }
+                },
+                "id": "4247722655768577",
+                "paging_token": "4247722655768577",
+                "transaction_successful": true,
+                "source_account": "[source_address]",
+                "type": "payment",
+                "type_i": 1,
+                "created_at": "2020-03-31T19:11:40Z",
+                "transaction_hash": "6dd25f3b8dcee0b924394fe0ee620d69157e5c5011922c67c651fcad2a9c510c",
+                "asset_type": "native",
+                "from": "[source_address]",
+                "to": "GDPISGR5YOIB7SNKKNWIOMKDS6Q6QQGJK5NG77NTIMMVW5JKK3DC4ZII",
+                "amount": "0.5500000"
+              }
+            ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 19:11:44 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_submit_transaction/doesn_t_raise_an_error_when_a_transaction_has_a_memo.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_submit_transaction/doesn_t_raise_an_error_when_a_transaction_has_a_memo.yml
@@ -1,0 +1,285 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Wed, 01 Apr 2020 18:33:37 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2499'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "accounts": {
+              "href": "https://horizon-testnet.stellar.org/accounts{?signer,asset,cursor,limit,order}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "offer": {
+              "href": "https://horizon-testnet.stellar.org/offers/{offer_id}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/offers{?selling,buying,seller,cursor,limit,order}",
+              "templated": true
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "strict_receive_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-receive{?source_assets,source_account,destination_account,destination_asset_type,destination_asset_issuer,destination_asset_code,destination_amount}",
+              "templated": true
+            },
+            "strict_send_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-send{?destination_account,destination_assets,source_asset_type,source_asset_issuer,source_asset_code,source_amount}",
+              "templated": true
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "1.0.1-2c2d8fb0c3ae0516dcbbb39f189ca00731c9c8c3",
+          "core_version": "stellar-core 12.4.0 (c0136139802ac1a1ac8899424e7888fa9366414e)",
+          "ingest_latest_ledger": 1004402,
+          "history_latest_ledger": 1004402,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 1004403,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "current_protocol_version": 12,
+          "core_supported_protocol_version": 12
+        }
+    http_version: 
+  recorded_at: Wed, 01 Apr 2020 18:33:37 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Wed, 01 Apr 2020 18:33:37 GMT
+      Latest-Ledger:
+      - '1004403'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2386'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H",
+          "account_id": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H",
+          "sequence": "4188147164381197",
+          "subentry_count": 0,
+          "last_modified_ledger": 989125,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9199.9999000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H"
+        }
+    http_version: 
+  recorded_at: Wed, 01 Apr 2020 18:33:37 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAFisHxErCBTGhhw2czhn5IiZ9C3khBTz324M39BDwnsrAAAAZAAO4RkAAAAOAAAAAQAAAAAAAAAAAAAAAF6E4NkAAAABAAAACXRlc3QgbWVtbwAAAAAAAAEAAAAAAAAAAQAAAAB1%2FDiWKkQxV8It81gQUHctapeM050vX6nKruTnPtSqFQAAAAAAAAAAO5rKAAAAAAAAAAABQ8J7KwAAAEA5oWrVU6b0kpTsM%2BwRuSrO%2BKMVALm1atauc%2BlNR6AM6XM2EehIkCI49orcymOC%2BCyOaS4nPpxSSKqo5mMiXNgB
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Wed, 01 Apr 2020 18:33:42 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1484'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/9bf815fd40291c1b696799ea1901f12bc4766ddd517bf1493a73e5f8988f4004"
+            }
+          },
+          "hash": "9bf815fd40291c1b696799ea1901f12bc4766ddd517bf1493a73e5f8988f4004",
+          "ledger": 1004404,
+          "envelope_xdr": "AAAAAFisHxErCBTGhhw2czhn5IiZ9C3khBTz324M39BDwnsrAAAAZAAO4RkAAAAOAAAAAQAAAAAAAAAAAAAAAF6E4NkAAAABAAAACXRlc3QgbWVtbwAAAAAAAAEAAAAAAAAAAQAAAAB1/DiWKkQxV8It81gQUHctapeM050vX6nKruTnPtSqFQAAAAAAAAAAO5rKAAAAAAAAAAABQ8J7KwAAAEA5oWrVU6b0kpTsM+wRuSrO+KMVALm1atauc+lNR6AM6XM2EehIkCI49orcymOC+CyOaS4nPpxSSKqo5mMiXNgB",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA9TdAAAAAAAAAAAWKwfESsIFMaGHDZzOGfkiJn0LeSEFPPfbgzf0EPCeysAAAAVa6CTtAAO4RkAAAANAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA9TdAAAAAAAAAAAWKwfESsIFMaGHDZzOGfkiJn0LeSEFPPfbgzf0EPCeysAAAAVa6CTtAAO4RkAAAAOAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMADxfEAAAAAAAAAAB1/DiWKkQxV8It81gQUHctapeM050vX6nKruTnPtSqFQAAABklTTecAA7hMQAAAAEAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAD1N0AAAAAAAAAAB1/DiWKkQxV8It81gQUHctapeM050vX6nKruTnPtSqFQAAABlg6AGcAA7hMQAAAAEAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAD1N0AAAAAAAAAABYrB8RKwgUxoYcNnM4Z+SImfQt5IQU899uDN/QQ8J7KwAAABVroJO0AA7hGQAAAA4AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAD1N0AAAAAAAAAABYrB8RKwgUxoYcNnM4Z+SImfQt5IQU899uDN/QQ8J7KwAAABUwBcm0AA7hGQAAAA4AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Wed, 01 Apr 2020 18:33:42 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_submit_transaction/fails_for_a_mix_of_operations_memo_not_included.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_submit_transaction/fails_for_a_mix_of_operations_memo_not_included.yml
@@ -1,0 +1,342 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Wed, 01 Apr 2020 18:43:24 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2499'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "accounts": {
+              "href": "https://horizon-testnet.stellar.org/accounts{?signer,asset,cursor,limit,order}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "offer": {
+              "href": "https://horizon-testnet.stellar.org/offers/{offer_id}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/offers{?selling,buying,seller,cursor,limit,order}",
+              "templated": true
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "strict_receive_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-receive{?source_assets,source_account,destination_account,destination_asset_type,destination_asset_issuer,destination_asset_code,destination_amount}",
+              "templated": true
+            },
+            "strict_send_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-send{?destination_account,destination_assets,source_asset_type,source_asset_issuer,source_asset_code,source_amount}",
+              "templated": true
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "1.0.1-2c2d8fb0c3ae0516dcbbb39f189ca00731c9c8c3",
+          "core_version": "stellar-core 12.4.0 (c0136139802ac1a1ac8899424e7888fa9366414e)",
+          "ingest_latest_ledger": 1004514,
+          "history_latest_ledger": 1004514,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 1004514,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "current_protocol_version": 12,
+          "core_supported_protocol_version": 12
+        }
+    http_version: 
+  recorded_at: Wed, 01 Apr 2020 18:43:25 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Wed, 01 Apr 2020 18:43:25 GMT
+      Latest-Ledger:
+      - '1004514'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2387'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H",
+          "account_id": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H",
+          "sequence": "4188147164381213",
+          "subentry_count": 0,
+          "last_modified_ledger": 1004503,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "8699.9998000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H"
+        }
+    http_version: 
+  recorded_at: Wed, 01 Apr 2020 18:43:25 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Wed, 01 Apr 2020 18:43:25 GMT
+      Latest-Ledger:
+      - '1004514'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2426'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B",
+          "account_id": "GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B",
+          "sequence": "4188250243596289",
+          "subentry_count": 1,
+          "last_modified_ledger": 1004503,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "11299.9999900",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {
+            "config.memo_required": "MQ=="
+          },
+          "paging_token": "GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B"
+        }
+    http_version: 
+  recorded_at: Wed, 01 Apr 2020 18:43:25 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_submit_transaction/raises_an_error_for_missing_memo.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_submit_transaction/raises_an_error_for_missing_memo.yml
@@ -1,0 +1,342 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Wed, 01 Apr 2020 18:33:42 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2499'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "accounts": {
+              "href": "https://horizon-testnet.stellar.org/accounts{?signer,asset,cursor,limit,order}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "offer": {
+              "href": "https://horizon-testnet.stellar.org/offers/{offer_id}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/offers{?selling,buying,seller,cursor,limit,order}",
+              "templated": true
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "strict_receive_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-receive{?source_assets,source_account,destination_account,destination_asset_type,destination_asset_issuer,destination_asset_code,destination_amount}",
+              "templated": true
+            },
+            "strict_send_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-send{?destination_account,destination_assets,source_asset_type,source_asset_issuer,source_asset_code,source_amount}",
+              "templated": true
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "1.0.1-2c2d8fb0c3ae0516dcbbb39f189ca00731c9c8c3",
+          "core_version": "stellar-core 12.4.0 (c0136139802ac1a1ac8899424e7888fa9366414e)",
+          "ingest_latest_ledger": 1004404,
+          "history_latest_ledger": 1004404,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 1004404,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "current_protocol_version": 12,
+          "core_supported_protocol_version": 12
+        }
+    http_version: 
+  recorded_at: Wed, 01 Apr 2020 18:33:42 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Wed, 01 Apr 2020 18:33:42 GMT
+      Latest-Ledger:
+      - '1004404'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2387'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H",
+          "account_id": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H",
+          "sequence": "4188147164381198",
+          "subentry_count": 0,
+          "last_modified_ledger": 1004404,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9099.9998900",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H"
+        }
+    http_version: 
+  recorded_at: Wed, 01 Apr 2020 18:33:43 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Wed, 01 Apr 2020 18:33:43 GMT
+      Latest-Ledger:
+      - '1004404'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2426'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B",
+          "account_id": "GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B",
+          "sequence": "4188250243596289",
+          "subentry_count": 1,
+          "last_modified_ledger": 1004404,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "10899.9999900",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {
+            "config.memo_required": "MQ=="
+          },
+          "paging_token": "GB27YOEWFJCDCV6CFXZVQECQO4WWVF4M2OOS6X5JZKXOJZZ62SVBKQ6B"
+        }
+    http_version: 
+  recorded_at: Wed, 01 Apr 2020 18:33:43 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_submit_transaction/succeeds_for_a_mix_of_operations_memo_included.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_submit_transaction/succeeds_for_a_mix_of_operations_memo_included.yml
@@ -1,0 +1,285 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Wed, 01 Apr 2020 18:33:43 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2499'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "accounts": {
+              "href": "https://horizon-testnet.stellar.org/accounts{?signer,asset,cursor,limit,order}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "offer": {
+              "href": "https://horizon-testnet.stellar.org/offers/{offer_id}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/offers{?selling,buying,seller,cursor,limit,order}",
+              "templated": true
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "strict_receive_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-receive{?source_assets,source_account,destination_account,destination_asset_type,destination_asset_issuer,destination_asset_code,destination_amount}",
+              "templated": true
+            },
+            "strict_send_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-send{?destination_account,destination_assets,source_asset_type,source_asset_issuer,source_asset_code,source_amount}",
+              "templated": true
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "1.0.1-2c2d8fb0c3ae0516dcbbb39f189ca00731c9c8c3",
+          "core_version": "stellar-core 12.4.0 (c0136139802ac1a1ac8899424e7888fa9366414e)",
+          "ingest_latest_ledger": 1004404,
+          "history_latest_ledger": 1004404,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 1004404,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "current_protocol_version": 12,
+          "core_supported_protocol_version": 12
+        }
+    http_version: 
+  recorded_at: Wed, 01 Apr 2020 18:33:43 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Wed, 01 Apr 2020 18:33:44 GMT
+      Latest-Ledger:
+      - '1004404'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2387'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H",
+          "account_id": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H",
+          "sequence": "4188147164381198",
+          "subentry_count": 0,
+          "last_modified_ledger": 1004404,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "9099.9998900",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H"
+        }
+    http_version: 
+  recorded_at: Wed, 01 Apr 2020 18:33:44 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAFisHxErCBTGhhw2czhn5IiZ9C3khBTz324M39BDwnsrAAAAyAAO4RkAAAAPAAAAAQAAAAAAAAAAAAAAAF6E4OAAAAABAAAACXRlc3QgbWVtbwAAAAAAAAIAAAAAAAAAAQAAAAB1%2FDiWKkQxV8It81gQUHctapeM050vX6nKruTnPtSqFQAAAAAAAAAAO5rKAAAAAAAAAAALAA7hGQAAABEAAAAAAAAAAUPCeysAAABArBwHax7O1Qd18fQlLGbHNgfB61HEG6G7sPtz%2BiKw5qbcINVk6n2rF9LbNelFEE8BRiAwmRnEPOSaxmmXfh%2FJCA%3D%3D
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Wed, 01 Apr 2020 18:33:47 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1784'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/0eab03c97af039be7ba22cc237734eb371f8c8a0f7e2fb4868fe8effe458fe36"
+            }
+          },
+          "hash": "0eab03c97af039be7ba22cc237734eb371f8c8a0f7e2fb4868fe8effe458fe36",
+          "ledger": 1004405,
+          "envelope_xdr": "AAAAAFisHxErCBTGhhw2czhn5IiZ9C3khBTz324M39BDwnsrAAAAyAAO4RkAAAAPAAAAAQAAAAAAAAAAAAAAAF6E4OAAAAABAAAACXRlc3QgbWVtbwAAAAAAAAIAAAAAAAAAAQAAAAB1/DiWKkQxV8It81gQUHctapeM050vX6nKruTnPtSqFQAAAAAAAAAAO5rKAAAAAAAAAAALAA7hGQAAABEAAAAAAAAAAUPCeysAAABArBwHax7O1Qd18fQlLGbHNgfB61HEG6G7sPtz+iKw5qbcINVk6n2rF9LbNelFEE8BRiAwmRnEPOSaxmmXfh/JCA==",
+          "result_xdr": "AAAAAAAAAMgAAAAAAAAAAgAAAAAAAAABAAAAAAAAAAAAAAALAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA9TdQAAAAAAAAAAWKwfESsIFMaGHDZzOGfkiJn0LeSEFPPfbgzf0EPCeysAAAAVMAXI7AAO4RkAAAAOAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA9TdQAAAAAAAAAAWKwfESsIFMaGHDZzOGfkiJn0LeSEFPPfbgzf0EPCeysAAAAVMAXI7AAO4RkAAAAPAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAACAAAABAAAAAMAD1N0AAAAAAAAAAB1/DiWKkQxV8It81gQUHctapeM050vX6nKruTnPtSqFQAAABlg6AGcAA7hMQAAAAEAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAD1N1AAAAAAAAAAB1/DiWKkQxV8It81gQUHctapeM050vX6nKruTnPtSqFQAAABmcgsucAA7hMQAAAAEAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAD1N1AAAAAAAAAABYrB8RKwgUxoYcNnM4Z+SImfQt5IQU899uDN/QQ8J7KwAAABUwBcjsAA7hGQAAAA8AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAD1N1AAAAAAAAAABYrB8RKwgUxoYcNnM4Z+SImfQt5IQU899uDN/QQ8J7KwAAABT0av7sAA7hGQAAAA8AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAIAAAADAA9TdQAAAAAAAAAAWKwfESsIFMaGHDZzOGfkiJn0LeSEFPPfbgzf0EPCeysAAAAU9Gr+7AAO4RkAAAAPAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA9TdQAAAAAAAAAAWKwfESsIFMaGHDZzOGfkiJn0LeSEFPPfbgzf0EPCeysAAAAU9Gr+7AAO4RkAAAARAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAA="
+        }
+    http_version: 
+  recorded_at: Wed, 01 Apr 2020 18:33:47 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_submit_transaction/succeeds_for_operations_that_don_t_require_memos.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_submit_transaction/succeeds_for_operations_that_don_t_require_memos.yml
@@ -1,0 +1,285 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Wed, 01 Apr 2020 18:33:52 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2499'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "accounts": {
+              "href": "https://horizon-testnet.stellar.org/accounts{?signer,asset,cursor,limit,order}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "offer": {
+              "href": "https://horizon-testnet.stellar.org/offers/{offer_id}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/offers{?selling,buying,seller,cursor,limit,order}",
+              "templated": true
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "strict_receive_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-receive{?source_assets,source_account,destination_account,destination_asset_type,destination_asset_issuer,destination_asset_code,destination_amount}",
+              "templated": true
+            },
+            "strict_send_paths": {
+              "href": "https://horizon-testnet.stellar.org/paths/strict-send{?destination_account,destination_assets,source_asset_type,source_asset_issuer,source_asset_code,source_amount}",
+              "templated": true
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "1.0.1-2c2d8fb0c3ae0516dcbbb39f189ca00731c9c8c3",
+          "core_version": "stellar-core 12.4.0 (c0136139802ac1a1ac8899424e7888fa9366414e)",
+          "ingest_latest_ledger": 1004406,
+          "history_latest_ledger": 1004406,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 1004406,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "current_protocol_version": 12,
+          "core_supported_protocol_version": 12
+        }
+    http_version: 
+  recorded_at: Wed, 01 Apr 2020 18:33:52 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Wed, 01 Apr 2020 18:33:52 GMT
+      Latest-Ledger:
+      - '1004406'
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '2387'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H",
+          "account_id": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H",
+          "sequence": "4188147164381204",
+          "subentry_count": 0,
+          "last_modified_ledger": 1004406,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false,
+            "auth_immutable": false
+          },
+          "balances": [
+            {
+              "balance": "8899.9998500",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "weight": 1,
+              "key": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {},
+          "paging_token": "GBMKYHYRFMEBJRUGDQ3HGODH4SEJT5BN4SCBJ467NYGN7UCDYJ5SXC6H"
+        }
+    http_version: 
+  recorded_at: Wed, 01 Apr 2020 18:33:53 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAFisHxErCBTGhhw2czhn5IiZ9C3khBTz324M39BDwnsrAAAAZAAO4RkAAAAVAAAAAQAAAAAAAAAAAAAAAF6E4OkAAAAAAAAAAQAAAAAAAAALAA7hGQAAABcAAAAAAAAAAUPCeysAAABAJ13WddZrDqsm9%2Biu87Z9ry7CqqSSRBc59xIoBBeJ6%2BLMQ3ufsSUdvlVK%2FTg5Cdzxv4NQjTpLd1Esv5bzRwnnDg%3D%3D
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      X-Client-Name:
+      - ruby-stellar-sdk
+      X-Client-Version:
+      - 0.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Wed, 01 Apr 2020 18:33:57 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '101'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1'
+      Content-Length:
+      - '1156'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/4a4226393fc9f2780da9c2c4fb390dba18ec641aeeb8ef473e1f58203061d565"
+            }
+          },
+          "hash": "4a4226393fc9f2780da9c2c4fb390dba18ec641aeeb8ef473e1f58203061d565",
+          "ledger": 1004407,
+          "envelope_xdr": "AAAAAFisHxErCBTGhhw2czhn5IiZ9C3khBTz324M39BDwnsrAAAAZAAO4RkAAAAVAAAAAQAAAAAAAAAAAAAAAF6E4OkAAAAAAAAAAQAAAAAAAAALAA7hGQAAABcAAAAAAAAAAUPCeysAAABAJ13WddZrDqsm9+iu87Z9ry7CqqSSRBc59xIoBBeJ6+LMQ3ufsSUdvlVK/Tg5Cdzxv4NQjTpLd1Esv5bzRwnnDg==",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAALAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAA9TdwAAAAAAAAAAWKwfESsIFMaGHDZzOGfkiJn0LeSEFPPfbgzf0EPCeysAAAAUuNAzwAAO4RkAAAAUAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA9TdwAAAAAAAAAAWKwfESsIFMaGHDZzOGfkiJn0LeSEFPPfbgzf0EPCeysAAAAUuNAzwAAO4RkAAAAVAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAgAAAAMAD1N3AAAAAAAAAABYrB8RKwgUxoYcNnM4Z+SImfQt5IQU899uDN/QQ8J7KwAAABS40DPAAA7hGQAAABUAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAD1N3AAAAAAAAAABYrB8RKwgUxoYcNnM4Z+SImfQt5IQU899uDN/QQ8J7KwAAABS40DPAAA7hGQAAABcAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Wed, 01 Apr 2020 18:33:57 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_transactions/account_transactions/accepts_a_cursor_to_return_less_data.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_transactions/account_transactions/accepts_a_cursor_to_return_less_data.yml
@@ -1,0 +1,94 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.1
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 18 May 2018 21:08:21 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d1358cdcd615404d320c3085a816645201526677701; expires=Sat, 18-May-19
+        21:08:21 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17176'
+      X-Ratelimit-Reset:
+      - '1685'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41d14c719b01b9f4-ATL
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://horizon-testnet.stellar.org/friendbot{?addr}",
+              "templated": true
+            },
+            "metrics": {
+              "href": "https://horizon-testnet.stellar.org/metrics"
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_issuer,buying_asset_type,buying_asset_code,buying_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "snapshot-snapshots-2-g99e33f0",
+          "core_version": "stellar-core 9.2.0rc6 (b0923f153b86d394a83b2a619db6b23f07ed0700)",
+          "history_latest_ledger": 9034899,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 9034899,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "protocol_version": 9
+        }
+    http_version: 
+  recorded_at: Fri, 18 May 2018 21:08:21 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_transactions/account_transactions/returns_a_list_of_transaction_for_an_account.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_transactions/account_transactions/returns_a_list_of_transaction_for_an_account.yml
@@ -1,0 +1,94 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.1
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 18 May 2018 21:05:24 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dd9cd962f0940437aacf5ef980a3ccb091526677524; expires=Sat, 18-May-19
+        21:05:24 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17177'
+      X-Ratelimit-Reset:
+      - '1861'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41d1482239c1b9e8-ATL
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://horizon-testnet.stellar.org/friendbot{?addr}",
+              "templated": true
+            },
+            "metrics": {
+              "href": "https://horizon-testnet.stellar.org/metrics"
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_issuer,buying_asset_type,buying_asset_code,buying_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "snapshot-snapshots-2-g99e33f0",
+          "core_version": "stellar-core 9.2.0rc6 (b0923f153b86d394a83b2a619db6b23f07ed0700)",
+          "history_latest_ledger": 9034864,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 9034864,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "protocol_version": 9
+        }
+    http_version: 
+  recorded_at: Fri, 18 May 2018 21:05:24 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_transactions/all_transactions/accepts_a_cursor_to_return_less_data.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_transactions/all_transactions/accepts_a_cursor_to_return_less_data.yml
@@ -1,0 +1,94 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.1
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 18 May 2018 21:32:24 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d9519f3eef6e4e8eb00700cd062f9854a1526679144; expires=Sat, 18-May-19
+        21:32:24 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17170'
+      X-Ratelimit-Reset:
+      - '242'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41d16fae3d85b9d0-ATL
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://horizon-testnet.stellar.org/friendbot{?addr}",
+              "templated": true
+            },
+            "metrics": {
+              "href": "https://horizon-testnet.stellar.org/metrics"
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_issuer,buying_asset_type,buying_asset_code,buying_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "snapshot-snapshots-2-g99e33f0",
+          "core_version": "stellar-core 9.2.0rc6 (b0923f153b86d394a83b2a619db6b23f07ed0700)",
+          "history_latest_ledger": 9035188,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 9035188,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "protocol_version": 9
+        }
+    http_version: 
+  recorded_at: Fri, 18 May 2018 21:32:24 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_transactions/all_transactions/returns_a_list_of_transactions.yml
+++ b/horizon/spec/fixtures/vcr_cassettes/Stellar_Horizon_Client/_transactions/all_transactions/returns_a_list_of_transactions.yml
@@ -1,0 +1,94 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.1
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 18 May 2018 21:32:24 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d64b3b4f7b1e989c1cb221b3ba0ca543e1526679144; expires=Sat, 18-May-19
+        21:32:24 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17177'
+      X-Ratelimit-Reset:
+      - '525'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41d16fac6868b9d6-ATL
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://horizon-testnet.stellar.org/friendbot{?addr}",
+              "templated": true
+            },
+            "metrics": {
+              "href": "https://horizon-testnet.stellar.org/metrics"
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_issuer,buying_asset_type,buying_asset_code,buying_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "snapshot-snapshots-2-g99e33f0",
+          "core_version": "stellar-core 9.2.0rc6 (b0923f153b86d394a83b2a619db6b23f07ed0700)",
+          "history_latest_ledger": 9035188,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 9035188,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "protocol_version": 9
+        }
+    http_version: 
+  recorded_at: Fri, 18 May 2018 21:32:24 GMT
+recorded_with: VCR 3.0.3

--- a/horizon/spec/lib/stellar/horizon/client_spec.rb
+++ b/horizon/spec/lib/stellar/horizon/client_spec.rb
@@ -1,0 +1,697 @@
+RSpec.describe Stellar::Horizon::Client do
+  subject(:client) { described_class.default_testnet }
+
+  describe "headers" do
+    let(:headers) { client.horizon.headers }
+
+    it "has 'Accept'" do
+      expect(headers["Accept"])
+        .to eq "application/hal+json,application/problem+json,application/json"
+    end
+
+    it "has 'X-Client-Name'" do
+      expect(headers["X-Client-Name"]).to eq "ruby-stellar-sdk"
+    end
+
+    it "has 'X-Client-Version'" do
+      expect(headers["X-Client-Version"]).to eq Stellar::Horizon::VERSION
+    end
+  end
+
+  describe "#default_testnet" do
+    it "instantiates a client pointing to horizon testnet" do
+      client = described_class.default_testnet
+      expect(client.horizon._url).to eq(described_class::HORIZON_TESTNET_URL)
+    end
+  end
+
+  describe "#default" do
+    it "instantiates a client pointing to horizon mainnet" do
+      client = described_class.default
+      expect(client.horizon._url).to eq(described_class::HORIZON_MAINNET_URL)
+    end
+  end
+
+  describe "#localhost" do
+    it "instantiates a client pointing to localhost horizon" do
+      client = described_class.localhost
+      expect(client.horizon._url).to eq(described_class::HORIZON_LOCALHOST_URL)
+    end
+  end
+
+  describe "#initialize" do
+    let(:custom_horizon_url) { "https://horizon.domain.com" }
+    it "instantiates a client accepting custom options" do
+      client = described_class.new(horizon: custom_horizon_url)
+      expect(client.horizon._url).to eq(custom_horizon_url)
+    end
+  end
+
+  describe "#friendbot" do
+    let(:client) { described_class.default_testnet }
+    let(:account) { Stellar::Account.random }
+
+    it("requests for XLM from a friendbot", {
+      vcr: {record: :once, match_requests_on: [:method]}
+    }) do
+      response = client.friendbot(account)
+
+      expect(response).to be_success
+
+      destination_info = client.account_info(account)
+      balances = destination_info.balances
+      expect(balances).to_not be_empty
+      native_asset_balance_info = balances.find { |b|
+        b["asset_type"] == "native"
+      }
+      expect(native_asset_balance_info["balance"].to_f).to be > 0
+    end
+  end
+
+  describe "#create_account" do
+    let(:source) { Stellar::Account.from_seed(CONFIG[:source_seed]) }
+    let(:destination) { Stellar::Account.random }
+
+    it "creates the account", vcr: {record: :once, match_requests_on: [:method]} do
+      client.create_account(
+        funder: source,
+        account: destination,
+        starting_balance: 100
+      )
+
+      destination_info = client.account_info(destination)
+      balances = destination_info.balances
+      expect(balances).to_not be_empty
+      native_asset_balance_info = balances.find { |b|
+        b["asset_type"] == "native"
+      }
+      expect(native_asset_balance_info["balance"].to_f).to eq 100.0
+    end
+  end
+
+  describe "#account_info" do
+    let(:account) { Stellar::Account.from_seed(CONFIG[:source_seed]) }
+    let(:client) { described_class.default_testnet }
+
+    it "returns the current details for the account", vcr: {record: :once, match_requests_on: [:method]} do
+      response = client.account_info(account)
+
+      expect(response.id).to eq CONFIG[:source_address]
+      expect(response.paging_token).to be_empty
+      expect(response.sequence).to eq "346973227974715"
+      expect(response.subentry_count).to eq 0
+      expect(response.thresholds).to include("low_threshold" => 0, "med_threshold" => 0, "high_threshold" => 0)
+      expect(response.flags).to include("auth_required" => false, "auth_revocable" => false)
+      expect(response.balances).to include("balance" => "3494.9997500", "asset_type" => "native")
+      expect(response.signers).to include(
+        "public_key" => CONFIG[:source_address],
+        "weight" => 1,
+        "type" => "ed25519_public_key",
+        "key" => CONFIG[:source_address]
+      )
+      expect(response.data).to be_empty
+    end
+  end
+
+  describe "#account_merge" do
+    let(:funder) { Stellar::Account.from_seed(CONFIG[:source_seed]) }
+    let(:client) { described_class.default_testnet }
+    let(:source) { Stellar::Account.random }
+    let(:destination) { Stellar::Account.random }
+
+    it "merges source account into destination", vcr: {record: :once, match_requests_on: [:method]} do
+      [source, destination].each do |account|
+        client.create_account(
+          funder: funder,
+          account: account,
+          starting_balance: 100
+        )
+      end
+
+      client.account_merge(
+        account: source,
+        destination: destination
+      )
+
+      destination_info = client.account_info(destination)
+      native_asset_balance_info = destination_info.balances.find { |b|
+        b["asset_type"] == "native"
+      }
+      # balance of merged account is the balance of both accounts minus transaction fee for merge
+      expect(native_asset_balance_info["balance"].to_f).to eq 199.99999
+    end
+  end
+
+  describe "#send_payment" do
+    let(:source) { Stellar::Account.from_seed(CONFIG[:source_seed]) }
+
+    context "native asset" do
+      let(:destination) { Stellar::Account.random }
+
+      it "sends a native payment to the account", vcr: {record: :once, match_requests_on: [:method]} do
+        client.create_account(
+          funder: source,
+          account: destination,
+          starting_balance: 100
+        )
+
+        amount = Stellar::Amount.new(150)
+
+        client.send_payment(
+          from: source,
+          to: destination,
+          amount: amount
+        )
+
+        destination_info = client.account_info(destination)
+        balances = destination_info.balances
+        expect(balances).to_not be_empty
+        native_asset_balance_info = balances.find { |b|
+          b["asset_type"] == "native"
+        }
+        expect(native_asset_balance_info["balance"].to_f).to eq 250.0
+      end
+    end
+
+    context "alphanum4 asset" do
+      let(:issuer) { Stellar::Account.from_seed(CONFIG[:source_seed]) }
+      let(:destination) { Stellar::Account.random }
+
+      it("sends a alphanum4 asset to the destination", {
+        vcr: {record: :once, match_requests_on: [:method]}
+      }) do
+        client.create_account(
+          funder: issuer,
+          account: destination,
+          starting_balance: 2
+        )
+
+        client.change_trust(
+          asset: [:alphanum4, "BTC", issuer.keypair],
+          source: destination
+        )
+
+        asset = Stellar::Asset.alphanum4("BTC", source.keypair)
+        amount = Stellar::Amount.new(150, asset)
+        client.send_payment(
+          from: source,
+          to: destination,
+          amount: amount
+        )
+
+        destination_info = client.account_info(destination)
+        btc_balance = destination_info.balances.find { |b|
+          b["asset_code"] == "BTC"
+        }["balance"].to_f
+
+        expect(btc_balance).to eq 150.0
+      end
+    end
+
+    context "alphanum12 asset" do
+      let(:issuer) { Stellar::Account.from_seed(CONFIG[:source_seed]) }
+      let(:destination) { Stellar::Account.random }
+
+      it("sends a alphanum12 asset to the destination", {
+        vcr: {record: :once, match_requests_on: [:method]}
+      }) do
+        client.create_account(
+          funder: issuer,
+          account: destination,
+          starting_balance: 2
+        )
+
+        client.change_trust(
+          asset: [:alphanum12, "LONGNAME", issuer.keypair],
+          source: destination
+        )
+
+        asset = Stellar::Asset.alphanum12("LONGNAME", source.keypair)
+        amount = Stellar::Amount.new(150, asset)
+
+        client.send_payment(
+          from: source,
+          to: destination,
+          amount: amount
+        )
+
+        destination_info = client.account_info(destination)
+        btc_balance = destination_info.balances.find { |b|
+          b["asset_code"] == "LONGNAME"
+        }["balance"].to_f
+
+        expect(btc_balance).to eq 150.0
+      end
+    end
+
+    context "memo" do
+      let(:destination) { Stellar::Account.random }
+
+      it("accepts the memo attribute", {
+        vcr: {record: :once, match_requests_on: [:method]}
+      }) do
+        client.create_account(
+          funder: source,
+          account: destination,
+          starting_balance: 100
+        )
+
+        amount = Stellar::Amount.new(150)
+
+        client.send_payment(
+          from: source,
+          to: destination,
+          amount: amount,
+          memo: "DESUKA"
+        )
+
+        last_tx = client.account_info(destination)
+          .transactions(order: "desc")._get._embedded.records.first
+        expect(last_tx.memo).to eq "DESUKA"
+      end
+    end
+
+    context "using a payment channel" do
+      let(:transaction_source) { Stellar::Account.from_seed(CONFIG[:channel_seed]) }
+      let(:destination) { Stellar::Account.random }
+
+      it("sends a payment account through a channel account", {
+        vcr: {record: :once, match_requests_on: [:method]}
+      }) do
+        client.create_account(
+          funder: source,
+          account: destination,
+          starting_balance: 1
+        )
+
+        tx = client.send_payment(
+          from: source,
+          to: destination,
+          amount: Stellar::Amount.new(0.55),
+          transaction_source: transaction_source
+        )
+
+        tx_hash = tx._attributes["hash"]
+
+        tx = client.horizon.transaction(hash: tx_hash)
+        expect(tx.source_account).to eq transaction_source.address
+
+        operation = tx.operations.records.first
+        expect(operation.from).to eq source.address
+
+        destination_info = client.account_info(destination)
+        balances = destination_info.balances
+        expect(balances).to_not be_empty
+        native_asset_balance_info = balances.find { |b|
+          b["asset_type"] == "native"
+        }
+        expect(native_asset_balance_info["balance"].to_f).to eq 1.55
+      end
+
+      it("sends a payment when the channel is the same as `from`", {
+        vcr: {record: :once, match_requests_on: [:method]}
+      }) do
+        client.create_account(
+          funder: source,
+          account: destination,
+          starting_balance: 1
+        )
+
+        tx = client.send_payment(
+          from: source,
+          to: destination,
+          amount: Stellar::Amount.new(0.55),
+          transaction_source: source
+        )
+
+        tx_hash = tx._attributes["hash"]
+
+        tx = client.horizon.transaction(hash: tx_hash)
+        expect(tx.source_account).to eq source.address
+
+        operation = tx.operations.records.first
+        expect(operation.from).to eq source.address
+      end
+    end
+  end
+
+  describe "#transactions" do
+    let(:cursor) { "348403452088320" }
+
+    context "account transactions" do
+      let(:account) { Stellar::Account.from_seed(CONFIG[:source_seed]) }
+
+      it "returns a list of transaction for an account", vcr: {record: :once, match_requests_on: [:method]} do
+        response = client.transactions(account: account)
+        expect(response).to be_a(Stellar::TransactionPage)
+      end
+
+      it "accepts a cursor to return less data", vcr: {record: :once, match_requests_on: [:method]} do
+        response = client.transactions(account: account, cursor: cursor)
+        expect(response).to be_a(Stellar::TransactionPage)
+      end
+    end
+
+    context "all transactions" do
+      it "returns a list of transactions", vcr: {record: :once, match_requests_on: [:method]} do
+        response = client.transactions
+        expect(response).to be_a(Stellar::TransactionPage)
+      end
+
+      it "accepts a cursor to return less data", vcr: {record: :once, match_requests_on: [:method]} do
+        response = client.transactions(cursor: cursor)
+        expect(response).to be_a(Stellar::TransactionPage)
+      end
+    end
+  end
+
+  describe "#change_trust" do
+    context "given an asset described as an array" do
+      let(:issuer) { Stellar::Account.from_seed(CONFIG[:source_seed]) }
+      let(:truster) { Stellar::Account.random }
+
+      it("creates, updates, or deletes a trustline", {
+        vcr: {record: :once, match_requests_on: [:method]}
+      }) do
+        client.create_account(
+          funder: issuer,
+          account: truster,
+          starting_balance: 2
+        )
+
+        # Create trustline
+        client.change_trust(
+          asset: [:alphanum4, "BTC", issuer.keypair],
+          source: truster
+        )
+
+        truster_info = client.account_info(truster)
+        btc_balance = truster_info.balances.find { |b|
+          b["asset_code"] == "BTC" && b["asset_issuer"] == issuer.address
+        }
+
+        expect(btc_balance).to_not be_nil
+
+        # Update trustline
+        client.change_trust(
+          asset: [:alphanum4, "BTC", issuer.keypair],
+          source: truster,
+          limit: 100
+        )
+
+        truster_info = client.account_info(truster)
+        btc_balance = truster_info.balances.find { |b|
+          b["asset_code"] == "BTC" && b["asset_issuer"] == issuer.address
+        }
+
+        expect(btc_balance["limit"].to_f).to eq 100
+
+        # Delete trustline
+        client.change_trust(
+          asset: [:alphanum4, "BTC", issuer.keypair],
+          source: truster,
+          limit: 0
+        )
+
+        truster_info = client.account_info(truster)
+        btc_balance = truster_info.balances.find { |b|
+          b["asset_code"] == "BTC" && b["asset_issuer"] == issuer.address
+        }
+
+        expect(btc_balance).to be_nil
+      end
+    end
+  end
+
+  describe "#submit_transaction" do
+    let(:kp) { Stellar::KeyPair.from_seed("SA27TR6PZVJOD24LJUBYQLJXYBXV6JW6ZZCJYLTHQ6KVMZZISC63SUBA") }
+    let(:memo_required_kp) { Stellar::KeyPair.from_seed("SAUZR3L5N43GQQZWO5HDSQJ76J65H5BUCNDRQB4DMA72ZJUXNUXVVTJY") }
+
+    it("doesn't raise an error when a transaction has a memo", {
+      vcr: {record: :once, match_requests_on: [:method]}
+    }) do
+      seq_num = client.account_info(kp.address).sequence.to_i + 1
+      tx = Stellar::TransactionBuilder.new(
+        source_account: kp,
+        sequence_number: seq_num,
+        memo: Stellar::Memo.new(:memo_text, "test memo")
+      ).add_operation(
+        Stellar::Operation.payment({
+          destination: memo_required_kp,
+          amount: [Stellar::Asset.native, 100]
+        })
+      ).set_timeout(600).build
+      envelope = tx.to_envelope(kp)
+
+      client.submit_transaction(tx_envelope: envelope)
+    end
+
+    it("raises an error for missing memo", {
+      vcr: {record: :once, match_requests_on: [:method]}
+    }) do
+      seq_num = client.account_info(kp.address).sequence.to_i + 1
+      tx = Stellar::TransactionBuilder.new(
+        source_account: kp,
+        sequence_number: seq_num
+      ).add_operation(
+        Stellar::Operation.payment({
+          destination: memo_required_kp,
+          amount: [Stellar::Asset.native, 100]
+        })
+      ).set_timeout(600).build
+      envelope = tx.to_envelope(kp)
+
+      expect {
+        client.submit_transaction(tx_envelope: envelope)
+      }.to raise_error(
+        an_instance_of(
+          Stellar::Horizon::AccountRequiresMemoError
+        ).and(
+          having_attributes(
+            message: "account requires memo",
+            account_id: memo_required_kp.muxed_account,
+            operation_index: 0
+          )
+        )
+      )
+    end
+
+    it("succeeds for a mix of operations, memo included", {
+      vcr: {record: :once, match_requests_on: [:method]}
+    }) do
+      seq_num = client.account_info(kp.address).sequence.to_i + 1
+      tx = Stellar::TransactionBuilder.new(
+        source_account: kp,
+        sequence_number: seq_num,
+        memo: Stellar::Memo.new(:memo_text, "test memo")
+      ).add_operation(
+        Stellar::Operation.payment({
+          destination: memo_required_kp,
+          amount: [Stellar::Asset.native, 100]
+        })
+      ).add_operation(
+        Stellar::Operation.bump_sequence({bump_to: seq_num + 2})
+      ).set_timeout(600).build
+      envelope = tx.to_envelope(kp)
+
+      client.submit_transaction(tx_envelope: envelope)
+    end
+
+    it("fails for a mix of operations, memo not included", {
+      vcr: {record: :once, match_requests_on: [:method]}
+    }) do
+      seq_num = client.account_info(kp.address).sequence.to_i + 1
+      tx = Stellar::TransactionBuilder.new(
+        source_account: kp,
+        sequence_number: seq_num
+      ).add_operation(
+        Stellar::Operation.bump_sequence({bump_to: seq_num + 2})
+      ).add_operation(
+        Stellar::Operation.payment({
+          destination: memo_required_kp,
+          amount: [Stellar::Asset.native, 100]
+        })
+      ).set_timeout(600).build
+      envelope = tx.to_envelope(kp)
+
+      expect {
+        client.submit_transaction(tx_envelope: envelope)
+      }.to raise_error(
+        an_instance_of(
+          Stellar::Horizon::AccountRequiresMemoError
+        ).and(
+          having_attributes(
+            message: "account requires memo",
+            account_id: memo_required_kp.muxed_account,
+            operation_index: 1
+          )
+        )
+      )
+    end
+
+    it("succeeds for operations that don't require memos", {
+      vcr: {record: :once, match_requests_on: [:method]}
+    }) do
+      seq_num = client.account_info(kp.address).sequence.to_i + 1
+      tx = Stellar::TransactionBuilder.new(
+        source_account: kp,
+        sequence_number: seq_num
+      ).add_operation(
+        Stellar::Operation.bump_sequence({bump_to: seq_num + 2})
+      ).set_timeout(600).build
+      envelope = tx.to_envelope(kp)
+
+      client.submit_transaction(tx_envelope: envelope)
+    end
+  end
+
+  # TODO refactor using contexts and moving tx building out of examples
+  describe "#check_memo_required" do
+    let(:kp) { Stellar::KeyPair.from_seed("SA27TR6PZVJOD24LJUBYQLJXYBXV6JW6ZZCJYLTHQ6KVMZZISC63SUBA") }
+    let(:memo_required_kp) { Stellar::KeyPair.from_seed("SAUZR3L5N43GQQZWO5HDSQJ76J65H5BUCNDRQB4DMA72ZJUXNUXVVTJY") }
+
+    it("raises an error for missing memo", {
+      vcr: {record: :once, match_requests_on: [:method]}
+    }) do
+      seq_num = client.account_info(kp.address).sequence.to_i + 1
+      tx = Stellar::TransactionBuilder.new(
+        source_account: kp,
+        sequence_number: seq_num
+      ).add_operation(
+        Stellar::Operation.payment({
+          destination: memo_required_kp,
+          amount: [Stellar::Asset.native, 100]
+        })
+      ).set_timeout(600).build
+      envelope = tx.to_envelope(kp)
+
+      expect {
+        client.check_memo_required(envelope)
+      }.to raise_error(
+        an_instance_of(
+          Stellar::Horizon::AccountRequiresMemoError
+        ).and(
+          having_attributes(
+            message: "account requires memo",
+            account_id: memo_required_kp.muxed_account,
+            operation_index: 0
+          )
+        )
+      )
+    end
+
+    it("raises an error for missing memo on account merge operations", {
+      vcr: {record: :once, match_requests_on: [:method]}
+    }) do
+      seq_num = client.account_info(kp.address).sequence.to_i + 1
+      tx = Stellar::TransactionBuilder.new(
+        source_account: kp,
+        sequence_number: seq_num
+      ).add_operation(
+        Stellar::Operation.account_merge({
+          destination: memo_required_kp
+        })
+      ).set_timeout(600).build
+      envelope = tx.to_envelope(kp)
+
+      expect {
+        client.check_memo_required(envelope)
+      }.to raise_error(
+        an_instance_of(
+          Stellar::Horizon::AccountRequiresMemoError
+        ).and(
+          having_attributes(
+            message: "account requires memo",
+            account_id: memo_required_kp.muxed_account,
+            operation_index: 0
+          )
+        )
+      )
+    end
+
+    it("succeeds with a multi-operation transaction", {
+      vcr: {record: :once, match_requests_on: [:method]}
+    }) do
+      seq_num = client.account_info(kp.address).sequence.to_i + 1
+      tx = Stellar::TransactionBuilder.new(
+        source_account: kp,
+        sequence_number: seq_num,
+        memo: Stellar::Memo.new(:memo_text, "test memo")
+      ).add_operation(
+        Stellar::Operation.payment({
+          destination: memo_required_kp,
+          amount: [Stellar::Asset.native, 100]
+        })
+      ).add_operation(
+        Stellar::Operation.account_merge({
+          destination: memo_required_kp
+        })
+      ).set_timeout(600).build
+      envelope = tx.to_envelope(kp)
+
+      client.check_memo_required(envelope)
+    end
+
+    it("doesn't raise an error when a transaction has a memo", {
+      vcr: {record: :once, match_requests_on: [:method]}
+    }) do
+      seq_num = client.account_info(kp.address).sequence.to_i + 1
+      tx = Stellar::TransactionBuilder.new(
+        source_account: kp,
+        sequence_number: seq_num,
+        memo: Stellar::Memo.new(:memo_text, "test memo")
+      ).add_operation(
+        Stellar::Operation.payment({
+          destination: memo_required_kp,
+          amount: [Stellar::Asset.native, 100]
+        })
+      ).set_timeout(600).build
+      envelope = tx.to_envelope(kp)
+
+      client.check_memo_required(envelope)
+    end
+
+    context "when destination is muxed account" do
+      it "skips the check" do
+      end
+    end
+
+    context "when tx is fee bump" do
+      let(:inner_tx_source) { Stellar::KeyPair.from_seed("SDV5KT5DLFVUA2OCBXQSKTZ7E7MBLEJ23UH5FDHGWTXFKOCN34GRR2BA") }
+      let(:fee_source) { Stellar::KeyPair.from_seed("SDHEM6T54CZ2OB3HM6JMHOXMLUI3GOGSR5VF26EO35I3NDWWZVPPHBGL") }
+
+      it "raises an error for missing memo", vcr: {record: :once, match_requests_on: [:method]} do
+        inner_tx_seq_num = client.account_info(inner_tx_source.address).sequence.to_i + 1
+
+        inner_tx = Stellar::TransactionBuilder.new(
+          source_account: inner_tx_source,
+          sequence_number: inner_tx_seq_num
+        ).add_operation(
+          Stellar::Operation.payment(
+            destination: memo_required_kp,
+            amount: [Stellar::Asset.native, 100]
+          )
+        ).set_timeout(0).build
+
+        fee_bump_seq_num = client.account_info(fee_source.address).sequence.to_i + 1
+
+        fee_bump_tx = Stellar::TransactionBuilder.new(
+          source_account: fee_source,
+          sequence_number: fee_bump_seq_num
+        ).build_fee_bump(inner_txe: inner_tx.to_envelope(inner_tx_source))
+
+        envelope = fee_bump_tx.to_envelope(fee_source)
+
+        expect { client.check_memo_required(envelope) }.to raise_error(
+          an_instance_of(Stellar::Horizon::AccountRequiresMemoError).and(
+            having_attributes(
+              message: "account requires memo",
+              account_id: memo_required_kp.muxed_account,
+              operation_index: 0
+            )
+          )
+        )
+      end
+    end
+  end
+end

--- a/horizon/spec/spec_helper.rb
+++ b/horizon/spec/spec_helper.rb
@@ -1,0 +1,30 @@
+require "simplecov"
+
+require "rspec/its"
+
+require_relative "../lib/stellar-horizon"
+
+require_relative "support/vcr"
+
+CONFIG = {
+  source_address: "GCIDYJRG5HV4WEESRA4LEKIMXLCU46XIKXGZK4PWX5K23PJIATMWR3UE",
+  source_seed: "SALQBNNRCXWD32E4QKIXKXCMXCPJKWUP34EAK53SP6PNGAUVWSAM5IUQ",
+  channel_address: "GBLVRKRL4NCY6MBDPRYMH4CQZMYME2CJGCVAD5YSRPDUS74AREQE7QOK",
+  channel_seed: "SAOS5HRNKGRGFVQQPEZOJN33MHUGHMS6GR3LB7GWFJFKSVSWIFYMQYFM"
+}
+
+RSpec.configure do |config|
+  config.include Stellar::DSL
+  config.filter_run_when_matching focus: true
+  config.run_all_when_everything_filtered = true
+
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end

--- a/horizon/spec/support/vcr.rb
+++ b/horizon/spec/support/vcr.rb
@@ -1,0 +1,10 @@
+require "vcr"
+
+VCR.configure do |config|
+  config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
+  config.hook_into :webmock
+  config.configure_rspec_metadata!
+  %i[source_address channel_address].each do |var|
+    config.filter_sensitive_data("[#{var}]") { CONFIG[var] }
+  end
+end

--- a/horizon/stellar-horizon.gemspec
+++ b/horizon/stellar-horizon.gemspec
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative "../base/lib/stellar/version"
+
+Gem::Specification.new do |spec|
+  spec.name = "stellar-horizon"
+  spec.version = Stellar::VERSION
+  spec.authors = ["Sergey Nebolsin", "Timur Ramazanov"]
+  spec.summary = "Stellar Horizon client library"
+  spec.homepage = "https://github.com/stellar/ruby-stellar-sdk/tree/master/horizon"
+  spec.license = "Apache-2.0"
+
+  spec.files = Dir["lib/**/*"]
+  spec.extra_rdoc_files += Dir["README*", "LICENSE*", "CHANGELOG*"]
+  spec.require_paths = ["lib"]
+  spec.bindir = "exe"
+
+  spec.metadata = {
+    "github_repo" => "ssh://github.com/astroband/ruby-stellar-sdk",
+    "documentation_uri" => "https://rubydoc.info/gems/stellar-sdk/#{spec.version}/",
+    "changelog_uri" => "https://github.com/astroband/ruby-stellar-sdk/blob/v#{spec.version}/horizon/CHANGELOG.md",
+    "source_code_uri" => "https://github.com/astroband/ruby-stellar-sdk/tree/v#{spec.version}/horizon"
+  }
+
+  spec.required_ruby_version = ">= 2.5.0"
+
+  spec.add_dependency "stellar-sdk", spec.version
+
+  spec.add_dependency "excon", ">= 0.71.0", "< 1.0"
+  spec.add_dependency "hyperclient", ">= 0.7.0", "< 2.0"
+  spec.add_dependency "toml-rb", ">= 1.1.1", "< 3.0"
+
+  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "rake", "~> 13"
+  spec.add_development_dependency "rspec", "~> 3.9"
+end

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Deprecated
+* `Stellar::Horizon` class, in favour of new `stellar-horizon` gem
+
 ## [0.28.0](https://www.github.com/astroband/ruby-stellar-sdk/compare/v0.27.0...v0.28.0) (2021-07-17)
 
 ### Changed

--- a/sdk/examples/01_get_funded.rb
+++ b/sdk/examples/01_get_funded.rb
@@ -1,4 +1,5 @@
 require "stellar-sdk"
+require "stellar-horizon"
 
 # Reference an account from a secret seed
 account = Stellar::Account.from_seed("SBXH4SEH32PENMMB66P4TY6LXUIFMRVFUMX2LJC3P2STHICBJLNQJOH5")
@@ -20,17 +21,17 @@ account = Stellar::Account.from_seed("SBXH4SEH32PENMMB66P4TY6LXUIFMRVFUMX2LJC3P2
 #
 
 # create a connection to the stellar network
-client = Stellar::Client.default_testnet
+client = Stellar::Horizon::Client.default_testnet
 
 # Further options
 #
 # Connect to the live network (when it is created)
 #
-#   client = Stellar::Client.default
+#   client = Stellar::Horizon::Client.default
 #
 # Connect to a specific horizon host
 #
-#   client = Stellar::Client.new(host: "127.0.0.1")
+#   client = Stellar::Horizon::Client.new(host: "127.0.0.1")
 
 # Get our friendly friendbot to
 # fund your new account

--- a/sdk/examples/02_payment.rb
+++ b/sdk/examples/02_payment.rb
@@ -1,6 +1,7 @@
 require "stellar-sdk"
+require "stellar-horizon"
 
-client = Stellar::Client.default_testnet
+client = Stellar::Horizon::Client.default_testnet
 
 puts "Creating random sender..."
 from = Stellar::KeyPair.random

--- a/sdk/examples/03_transaction_history.rb
+++ b/sdk/examples/03_transaction_history.rb
@@ -1,7 +1,8 @@
 require "stellar-sdk"
+require "stellar-horizon"
 
 account = Stellar::Account.from_seed("SBXH4SEH32PENMMB66P4TY6LXUIFMRVFUMX2LJC3P2STHICBJLNQJOH5")
-client = Stellar::Client.default_testnet
+client = Stellar::Horizon::Client.default_testnet
 
 # load the first page of transactions
 transactions = client.transactions({

--- a/sdk/examples/04_setting_trust.rb
+++ b/sdk/examples/04_setting_trust.rb
@@ -1,6 +1,7 @@
 require "stellar-sdk"
+require "stellar-horizon"
 
-client = Stellar::Client.default_testnet
+client = Stellar::Horizon::Client.default_testnet
 
 # A fake issuer for BTC
 issuer = Stellar::KeyPair.from_seed("SALQBNNRCXWD32E4QKIXKXCMXCPJKWUP34EAK53SP6PNGAUVWSAM5IUQ")

--- a/sdk/examples/05_fiat_payment.rb
+++ b/sdk/examples/05_fiat_payment.rb
@@ -1,6 +1,7 @@
 require "stellar-sdk"
+require "stellar-horizon"
 
-client = Stellar::Client.default_testnet
+client = Stellar::Horizon::Client.default_testnet
 
 def post_transaction(client, envelope)
   client.horizon.transactions._post(tx: envelope)

--- a/sdk/examples/07_sep10.rb
+++ b/sdk/examples/07_sep10.rb
@@ -1,7 +1,8 @@
 require "stellar-sdk"
+require "stellar-horizon"
 require "hyperclient"
 
-$client = Stellar::Client.default_testnet
+$client = Stellar::Horizon::Client.default_testnet
 $client_master_kp = Stellar::KeyPair.random
 $client_signer_kp1 = Stellar::KeyPair.random
 $client_signer_kp2 = Stellar::KeyPair.random

--- a/sdk/lib/stellar/client.rb
+++ b/sdk/lib/stellar/client.rb
@@ -44,6 +44,8 @@ module Stellar
 
     # @option options [String] :horizon The Horizon server URL.
     def initialize(options)
+      ActiveSupport::Deprecation.warn("`Stellar::Horizon` is deprecated and will be removed from `stellar-sdk` next relase. Use `stellar-horizon` gem for requesting Horizon API")
+
       @options = options
       @horizon = Hyperclient.new(options[:horizon]) { |client|
         client.faraday_block = lambda do |conn|

--- a/sdk/spec/lib/stellar/client_spec.rb
+++ b/sdk/spec/lib/stellar/client_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe Stellar::Client do
   subject(:client) { Stellar::Client.default_testnet }
 
+  around { |ex| ActiveSupport::Deprecation.silence(&ex) }
+
   describe "headers" do
     let(:headers) { client.horizon.headers }
 

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -12,14 +12,14 @@ namespace :test do
   end
 
   desc "Run spec task for all projects"
-  task spec: %i[spec:base spec:sdk]
+  task spec: %i[spec:base spec:sdk spec:horizon]
 
   rule(/coverage:.+$/) do |task|
     sh("cd #{task.name.split(":").last} && COVERAGE=true ../bin/rspec")
   end
 
   desc "Generate code coverage for all projects"
-  task coverage: %i[coverage:base coverage:sdk]
+  task coverage: %i[coverage:base coverage:sdk coverage:horizon]
 
   task all: %i[spec]
 end


### PR DESCRIPTION
# Description

This PR creates separate gem, which is devoted to Horizon interactions solely. For now it's just a copy-paste of current of the current client implementation in `stellar-sdk`