### PR TITLE
chore: release 0.29.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: base
   specs:
-    stellar-base (0.28.0)
+    stellar-base (0.29.0)
       activesupport (>= 5.0.0, < 7.0)
       base32 (>= 0.3.0, < 1.0)
       digest-crc (>= 0.5.0, < 1.0)
@@ -11,20 +11,20 @@ PATH
 PATH
   remote: horizon
   specs:
-    stellar-horizon (0.28.0)
+    stellar-horizon (0.29.0)
       excon (>= 0.71.0, < 1.0)
       hyperclient (>= 0.7.0, < 2.0)
-      stellar-sdk (= 0.28.0)
+      stellar-sdk (= 0.29.0)
       toml-rb (>= 1.1.1, < 3.0)
 
 PATH
   remote: sdk
   specs:
-    stellar-sdk (0.28.0)
+    stellar-sdk (0.29.0)
       activesupport (>= 5.0.0, < 7.0)
       excon (>= 0.71.0, < 1.0)
       hyperclient (>= 0.7.0, < 2.0)
-      stellar-base (= 0.28.0)
+      stellar-base (= 0.29.0)
       toml-rb (>= 1.1.1, < 3.0)
 
 GEM

--- a/base/CHANGELOG.md
+++ b/base/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
+## [0.29.0](https://www.github.com/astroband/ruby-stellar-sdk/compare/v0.28.0...v0.29.0) (2021-09-07)
+- No changes
+
 ## [0.28.0](https://www.github.com/astroband/ruby-stellar-sdk/compare/v0.27.0...v0.28.0) (2021-07-17)
 
 ### Features

--- a/base/lib/stellar/version.rb
+++ b/base/lib/stellar/version.rb
@@ -1,3 +1,3 @@
 module Stellar
-  VERSION = "0.28.0".freeze
+  VERSION = "0.29.0".freeze
 end

--- a/horizon/CHANGELOG.md
+++ b/horizon/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this
+file. The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+As this project is pre 1.0, breaking changes may happen for minor version
+bumps.  A breaking change will get clearly notified in this log.
+
+## [0.29.0](https://www.github.com/astroband/ruby-stellar-sdk/compare/v0.28.0...v0.29.0) (2021-09-07)
+
+### Added
+* Initial setup of the gem, copying all Horizon-related features from `sdk` gem

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.29.0](https://www.github.com/astroband/ruby-stellar-sdk/compare/v0.28.0...v0.29.0) (2021-09-07)
+
+### Added
+* support for client domain in SEP-10
+### Deprecated
+* `Stellar::Client` class is marked as deprecated in favour of new `stellar-horizon` gem
+
 ## [0.28.0](https://www.github.com/astroband/ruby-stellar-sdk/compare/v0.27.0...v0.28.0) (2021-07-17)
 
 ### Changed


### PR DESCRIPTION
## [0.29.0](https://www.github.com/astroband/ruby-stellar-sdk/compare/v0.28.0...v0.29.0) (2021-09-07)

### Features

* support for client domain in SEP-10 (#201) ([37cd954](https://www.github.com/astroband/ruby-stellar-sdk/commit/37cd954f92c7999a74ca779e795dde74a3d71aad))
* Horizon client is extracted to the separate gem (#194) ([e52ecc4](https://www.github.com/astroband/ruby-stellar-sdk/commit/e52ecc4a8d67623f945efdf002671b4e257ef5cc))