### PR TITLE
chore(ci): add CodeQL scan to security workflow

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,5 @@
+name: "Stellar Ruby SDK CodeQL Config"
+
+paths-ignore:
+# causes parsing err0r
+- base/lib/stellar/claim_predicate.rb

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,23 +6,41 @@ on:
     branches: [ main ]
   schedule:
   - cron: '43 0 * * 4'
+  workflow_dispatch: {}
 
 jobs:
-  semgrep:
-    name: Scan with Semgrep
+  codeql:
+    name: Scan with CodeQL
     runs-on: ubuntu-latest
-    # Skip any PR created by dependabot to avoid permission issues
-    if: (github.actor != 'dependabot[bot]')
+    permissions:
+      security-events: write
     steps:
     - uses: actions/checkout@v3
-    - name: Run Semgrep
-      uses: returntocorp/semgrep-action@v1
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
       with:
-        generateSarif: "1"
-        auditOn: push
-        publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
+        languages: ruby
+        config-file: .github/codeql/codeql-config.yml
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+
+  semgrep:
+    name: Scan with Semgrep
+    # Skip any PR created by dependabot to avoid permission issues
+    if: (github.actor != 'dependabot[bot]')
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+    steps:
+    - uses: actions/checkout@v3
+    - name: Semgrep Scan
+      run: semgrep scan --config=auto --sarif --output=semgrep.sarif
+      env:
+        SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     - name: Upload result to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v1
+      uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: semgrep.sarif
       if: always()
@@ -42,7 +60,7 @@ jobs:
       with:
         args: --sarif-file-output=snyk.sarif
     - name: Upload result to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v1
+      uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: snyk.sarif
       if: always()

--- a/bin/setup
+++ b/bin/setup
@@ -1,8 +1,5 @@
 #! /usr/bin/env bash
 
-set -o nounset
-set -o errexit
-set -o pipefail
-IFS=$'\n\t'
+set -o errexit -o nounset -o pipefail
 
 bundle install


### PR DESCRIPTION
Since [Ruby support has been added to CodeQL](https://github.blog/changelog/2021-10-27-codeql-code-scanning-adds-beta-support-for-ruby/) lets try to introduce CodeQL analysis to our security workflow.