### PR TITLE
Bump dependencies for use in Rails 8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,9 +14,9 @@ PATH
     stellar-horizon (0.32.0)
       excon (>= 0.71.0, < 1.0)
       faraday (>= 1.6.0, < 3.0)
-      faraday-excon (>= 1.1.0, < 3.0)
+      faraday-excon (~> 2.1)
       faraday-follow_redirects (>= 0.3.0, < 1.0)
-      hyperclient (>= 0.7.0, < 2.0)
+      hyperclient (~> 2.0)
       stellar-base (= 0.32.0)
 
 PATH
@@ -70,35 +70,15 @@ GEM
     drb (2.2.0)
       ruby2_keywords
     excon (0.109.0)
-    faraday (1.10.3)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
+    faraday (2.0.0)
       ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
+    faraday-excon (2.1.0)
+      excon (>= 0.27.4)
+      faraday (~> 2.0)
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
-    faraday_hal_middleware (0.1.1)
-      faraday_middleware (>= 0.9)
-    faraday_middleware (1.2.0)
-      faraday (~> 1.0)
+    faraday_hal_middleware (0.2.0)
+      faraday (~> 2.0)
     ffi (1.16.3)
     ffi (1.16.3-java)
     formatador (1.1.0)
@@ -118,11 +98,11 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashdiff (1.1.0)
-    hyperclient (1.0.1)
+    hyperclient (2.0.0)
       addressable
-      faraday (>= 0.9.0)
-      faraday_hal_middleware
-      faraday_middleware
+      faraday (>= 2)
+      faraday-follow_redirects
+      faraday_hal_middleware (>= 0.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
@@ -135,7 +115,6 @@ GEM
     lumberjack (1.2.8)
     method_source (1.0.0)
     minitest (5.21.1)
-    multipart-post (2.4.0)
     mutex_m (0.2.0)
     nenv (0.3.0)
     netrc (0.11.0)
@@ -256,6 +235,7 @@ GEM
       yard
 
 PLATFORMS
+  arm64-darwin-23
   java
   ruby
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: base
   specs:
-    stellar-base (0.32.0)
+    stellar-base (0.33.0)
       activesupport (>= 5.0.0, < 8.0)
       base32 (>= 0.3.0, < 1.0)
       digest-crc (>= 0.5.0, < 1.0)
@@ -11,22 +11,22 @@ PATH
 PATH
   remote: horizon
   specs:
-    stellar-horizon (0.32.0)
+    stellar-horizon (0.33.0)
       excon (>= 0.71.0, < 1.0)
       faraday (>= 1.6.0, < 3.0)
       faraday-excon (~> 2.1)
       faraday-follow_redirects (>= 0.3.0, < 1.0)
       hyperclient (~> 2.0)
-      stellar-base (= 0.32.0)
+      stellar-base (= 0.33.0)
 
 PATH
   remote: sdk
   specs:
-    stellar-sdk (0.32.0)
+    stellar-sdk (0.33.0)
       activesupport (>= 5.0.0, < 8.0)
       faraday (>= 1.6.0, < 3.0)
-      stellar-base (= 0.32.0)
-      stellar-horizon (= 0.32.0)
+      stellar-base (= 0.33.0)
+      stellar-horizon (= 0.33.0)
       tomlrb (>= 2.0.1, < 3.0)
 
 GEM

--- a/base/lib/stellar/version.rb
+++ b/base/lib/stellar/version.rb
@@ -1,3 +1,3 @@
 module Stellar
-  VERSION = "0.32.0".freeze
+  VERSION = "0.33.0".freeze
 end

--- a/horizon/lib/stellar/horizon/client.rb
+++ b/horizon/lib/stellar/horizon/client.rb
@@ -1,7 +1,7 @@
 require "hyperclient"
 require "active_support/core_ext/object/blank"
 require "securerandom"
-require 'faraday/excon'
+require "faraday/excon"
 
 module Stellar::Horizon
   class AccountRequiresMemoError < StandardError

--- a/horizon/stellar-horizon.gemspec
+++ b/horizon/stellar-horizon.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "excon", ">= 0.71.0", "< 1.0"
   spec.add_dependency "faraday", ">= 1.6.0", "< 3.0"
-  spec.add_dependency "faraday-excon", ">= 1.1.0", "< 3.0"
+  spec.add_dependency "faraday-excon", "~> 2.1"
   spec.add_dependency "faraday-follow_redirects", ">= 0.3.0", "< 1.0"
-  spec.add_dependency "hyperclient", ">= 0.7.0", "< 2.0"
+  spec.add_dependency "hyperclient", "~> 2.0"
 end


### PR DESCRIPTION
Builds on top of https://github.com/astroband/ruby-stellar-sdk/pull/428, but loosens ActiveSupport dependency so this can be used in Rails 8
